### PR TITLE
Fix Prokka inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ Initial release of nf-core/bacass, created with the [nf-core](http://nf-co.re/) 
 
 This pipeline is for bacterial assembly of next-generation sequencing reads. It can be used to quality trim your reads using [Skewer](https://github.com/relipmoc/skewer) and performs basic QC using [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/). Afterwards, the pipeline performs read assembly using [Unicycler](https://github.com/rrwick/Unicycler) and assesses assembly quality using [QUAST](http://bioinf.spbau.ru/quast). Contamination of the assembly is checked using [Kraken2](https://ccb.jhu.edu/software/kraken2/) to verify sample purity. The resulting bacterial assembly is annotated using [Prokka](https://github.com/tseemann/prokka).
 
-Furthermore, the pipeline creates various reports in the `results` directory specified, including a [MultiQC](https://multiqc.info) report summarizing some of the findings and software versions.
+Furthermore, the pipeline creates various reports in the `results` directory specified, including a [MultiQC](https://multiqc.info) report summarizing some of the findings and software versions. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ Initial release of nf-core/bacass, created with the [nf-core](http://nf-co.re/) 
 
 This pipeline is for bacterial assembly of next-generation sequencing reads. It can be used to quality trim your reads using [Skewer](https://github.com/relipmoc/skewer) and performs basic QC using [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/). Afterwards, the pipeline performs read assembly using [Unicycler](https://github.com/rrwick/Unicycler) and assesses assembly quality using [QUAST](http://bioinf.spbau.ru/quast). Contamination of the assembly is checked using [Kraken2](https://ccb.jhu.edu/software/kraken2/) to verify sample purity. The resulting bacterial assembly is annotated using [Prokka](https://github.com/tseemann/prokka).
 
-Furthermore, the pipeline creates various reports in the `results` directory specified, including a [MultiQC](https://multiqc.info) report summarizing some of the findings and software versions. 
+Furthermore, the pipeline creates various reports in the `results` directory specified, including a [MultiQC](https://multiqc.info) report summarizing some of the findings and software versions.

--- a/main.nf
+++ b/main.nf
@@ -337,7 +337,7 @@ process prokka {
    publishDir "${params.outdir}/${sample_id}/", mode: 'copy'
 
    input:
-   set sample_id, fasta from prokka_ch
+   set sample_id, file(fasta) from prokka_ch
 
    output:
    file("${sample_id}_annotation/")


### PR DESCRIPTION
I tried running this pipeline on AWS Batch and had an error with the Prokka process.  Looking at the logs, it seemed to think that the workDir was local rather than on S3.

I'm not an experienced Nextflow user but I notice that most of the other processes wrap file inputs with `file(...)`.  Does this look like a bug?  I've included the logs below:

```
nxf-scratch-dir ip-10-0-0-210.eu-west-2.compute.internal:/tmp/nxf.o3Vgx5LSx9
[01:14:41] This is prokka 1.13.3
[01:14:41] Written by Torsten Seemann <torsten.seemann@gmail.com>
[01:14:41] Homepage is https://github.com/tseemann/prokka
[01:14:41] Local time is Fri Sep 20 01:14:41 2019
[01:14:41] You are not telling me who you are!
[01:14:41] Operating system is linux
[01:14:41] You have BioPerl 1.007002
[01:14:41] System has 4 cores.
[01:14:41] Will use maximum of 4 cores.
[01:14:41] Annotating as >>> Bacteria <<<
[01:14:41] '/bt5-cli-test-filesbucket-1b9uci8nmnwcq/workDir/fd0577ae-2dd2-5f76-8c23-370435b7e62d/c8/f64036a144e1bb9cc77bca3c70d1ce/ERR124436_assembly.fasta' is not a readable non-empty FASTA file
```