### PR TITLE
Add in dfast as annotation tool now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         nxf_ver: ['19.10.0', '']
-        options: ["test,docker", "test_long,docker --assembler canu, "test_long_miniasm,docker", "test_hybrid,docker" ]
+        options: ["test,docker", "test_long,docker --assembler canu, "test_long_miniasm,docker", "test_hybrid,docker", "test,docker --annotation_tool dfast" ]
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,19 @@
   * Miniasm + Racon
   * Canu Assembler
   * Unicycler in Long read Mode
+* Add alternative assembly annotation using DFAST
 
 ### Dependency updates
 
 * Bumped Nextflow Version to 19.10.0
-* Various tools updated (will update before release!)
+
+## Added tools
+
+* DFAST
+* PycoQC
+* Nanoplot
+* PoreChop
+* Nanopolish
 
 ## v1.0.0 nf-core/bacass: "Green Tin Ant"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple bacterial assembly and annotation pipeline
 
-[![Build Status](https://travis-ci.com/nf-core/bacass.svg?branch=master)](https://travis-ci.com/nf-core/bacass)
+[![GitHub Actions](https://github.com/nf-core/bacass/workflows/nf-core%20CI/badge.svg)](https://github.com/nf-core/bacass/workflows/nf-core%20CI/badge.svg)
 [![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A519.10.0-brightgreen.svg)](https://www.nextflow.io/)
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,8 +11,10 @@
   * [Main Nextflow arguments](#main-nextflow-arguments)
     * [`-profile`](#profile)
   * [Main Pipeline Arguments](#main-pipeline-arguments)
+    * [`--annotation_tool`](#annotationtool)
     * [`--assembler`](#assembler)
     * [`--assembly_type`](#assemblytype)
+    * [`--dfast_config`](#dfastconfig)
     * [`--input`](#input)
     * [`--kraken2db`](#kraken2db)
     * [`--prokka_args`](#prokkaargs)
@@ -110,6 +112,10 @@ If `-profile` is not specified at all the pipeline will be run locally and expec
 
 ## Main Pipeline Arguments
 
+### `--annotation_tool`
+
+The annotation method to annotate the final assembly. Default choice is `prokka`, but the `dfast` tool is also available. For the latter, make sure to create your specific config if you're not happy with the default one provided. See [#dfast_config](#dfastconfig) to find out how.
+
 ### `--assembler`
 
 The assembler to use for assembly. Available options are `Unicycler`, `Canu`, `Miniasm`. The latter two are only available for long-read data, whereas Unicycler can be used for short or hybrid assembly projects.
@@ -117,6 +123,10 @@ The assembler to use for assembly. Available options are `Unicycler`, `Canu`, `M
 ### `--assembly_type`
 
 This adjusts the type of assembly done with the input data and can be any of `long`, `short` or `hybrid`. Short & Hybrid assembly will always run Unicycler, whereas long-read assembly can be configured separately using the `--assembler` parameter.
+
+### `--dfast_config`
+
+Specifies a configuration file for the [DFAST](https://github.com/nigyta/dfast_core) annotation method. This can be used instead of PROKKA if required to specify a specific config file for annotation. If you want to know how to create your config file, please refer to the [DFAST](https://github.com/nigyta/dfast_core) readme on how to create one.
 
 ### `--input`
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - skewer=0.2.2
   - kraken2=2.0.8_beta
   - prokka=1.14.5
-  - bandage=0.8.1
+  - bioconda::bandage=0.8.1
   # for markdown_to_html.r
   - r-markdown=1.1
   # Nanopore analysis stuff
@@ -21,9 +21,10 @@ dependencies:
   - conda-forge::parallel=20191122
   - miniasm=0.3_r179
   - racon=1.4.10
-  - canu=1.9
+  - bioconda::canu=1.9
   - minimap2=2.17
   - samtools=1.9
   - nanoplot=1.28.1
   - pycoqc=2.5.0.3
   - h5py=2.10.0 #until the pycoqc recipe has been updated
+  - dfast=1.2.5

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,6 @@
 params {
 
   // Workflow flags
-  singleEnd = false
   outdir = './results'
   skip_kraken2 = false
   kraken2db = ""
@@ -18,7 +17,8 @@ params {
   assembler = 'unicycler' //allowed are unicycler, canu, miniasm 
   //Short, Long or Hybrid assembly?
   assembly_type = 'short' //allowed are short, long, hybrid (hybrid works only with Unicycler)
-  
+  annotation_tool = 'prokka' //Default
+  dfast_config = "https://github.com/nigyta/dfast_core/blob/master/example/test_config.py"
   //Skipping parts
   skip_pycoqc = false
   skip_annotation = false


### PR DESCRIPTION
This adds support for DFAST as an alternative annotation method now. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/bacass branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/bacass)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated
