### PR TITLE
Fix: save_trimmed_fail is a boolean

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -44,7 +44,6 @@
             "properties": {
                 "save_trimmed_fail": {
                     "type": "boolean",
-                    "enum": ["true", "false"],
                     "description": "save files that failed to pass trimming thresholds ending in `*.fail.fastq.gz`"
                 },
                 "save_merged": {


### PR DESCRIPTION
save_trimmed_fail had conflicting settings for boolean and enum of two strings. This removes the enum option.

<!--
# nf-core/bacass pull request

Many thanks for contributing to nf-core/bacass!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
