### PR TITLE
Fix kmerfinder scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#154](https://github.com/nf-core/bacass/pull/154) Fixed kmerfinder script and increase resources to prevent memory issues.
 - [#153](https://github.com/nf-core/bacass/pull/153) Update `.nf-core.yml` to fix files_unchanged section for accurate linting checks.
 
 ### `Dependencies`

--- a/bin/download_reference.py
+++ b/bin/download_reference.py
@@ -122,7 +122,7 @@ def download_references(file, reference, out_dir):
             ref_query = f"{assembly_accession}_{asm_name}"
 
             # Check if ref_query matches the search value
-            if ref_query == top_reference:
+            if top_reference in ref_query:
                 # make url  # Append the 20th element of the row to the URL list:
                 assembly_url = row[19] + "/" + ref_query
                 dir_url.append(assembly_url)

--- a/modules/local/kmerfinder.nf
+++ b/modules/local/kmerfinder.nf
@@ -1,6 +1,6 @@
 process KMERFINDER {
     tag "$meta.id"
-    label 'process_medium'
+    label 'process_high'
 
     conda "bioconda::kmerfinder=3.0.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
<!--
# nf-core/bacass pull request

Many thanks for contributing to nf-core/bacass!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## PR description

Minor fix for the kmerfinder-related script and increased resources to avoid memory issues.

## Run test

Test of this PR can be run via:
`nextflow run main.nf -profile test_full,docker --outdir results`

or

```
nextflow run main.nf  \
    -profile test,docker \
    --skip_kmerfinder false \
    --kmerfinderdb 'https://zenodo.org/records/10458361/files/20190108_kmerfinder_stable_dirs.tar.gz?download=1' \
    --ncbi_assembly_metadata 'https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_refseq.txt' \
    --outdir results

```