### PR TITLE
Fixed current Zenodo URL of Kmerfinderdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#157](https://github.com/nf-core/bacass/pull/157) Fixed corrupted zenodo URL of Kmerfinder database.
 - [#154](https://github.com/nf-core/bacass/pull/154) Fixed kmerfinder script and increase resources to prevent memory issues.
 - [#153](https://github.com/nf-core/bacass/pull/153) Update `.nf-core.yml` to fix files_unchanged section for accurate linting checks.
 

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -17,6 +17,6 @@ params {
     // Input data for full size test
     input                       = params.pipelines_testdata_base_path + 'bacass/bacass_full.tsv'
     kraken2db                   = 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_8gb_20210517.tar.gz'
-    kmerfinderdb                = 'https://zenodo.org/records/10458361/files/20190108_kmerfinder_stable_dirs.tar.gz'
+    kmerfinderdb                = 'https://zenodo.org/records/13447056/files/20190108_kmerfinder_stable_dirs.tar.gz'
     ncbi_assembly_metadata      = 'https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_refseq.txt'
 }

--- a/modules/local/kmerfinder.nf
+++ b/modules/local/kmerfinder.nf
@@ -8,7 +8,8 @@ process KMERFINDER {
         'biocontainers/kmerfinder:3.0.2--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(reads), path(kmerfinder_db)
+    tuple val(meta), path(reads), path(kmerfinderdb_path)
+    val tax_group
 
     output:
     tuple val(meta), path("*_results.txt")  , emit: report
@@ -18,14 +19,15 @@ process KMERFINDER {
     script:
     def prefix   = task.ext.prefix ?: "${meta.id}"
     def in_reads = reads[0] && reads[1] ? "${reads[0]} ${reads[1]}" : "${reads}"
-    // WARNING: Ensure to update software version in this line if you modify the container/environment.
+    // WARNING: Ensure to update software or database version in this line if you modify the container/environment.
     def kmerfinder_version = "3.0.2"
+    def kmerfinderdb_version = "20190108"
     """
     kmerfinder.py \\
         --infile $in_reads \\
         --output_folder . \\
-        --db_path ${kmerfinder_db}/bacteria.ATG \\
-        -tax ${kmerfinder_db}/bacteria.name \\
+        --db_path ${kmerfinderdb_path}/${tax_group}/bacteria.ATG \\
+        -tax ${kmerfinderdb_path}/${tax_group}/bacteria.name \\
         -x
 
     mv results.txt ${prefix}_results.txt
@@ -34,6 +36,7 @@ process KMERFINDER {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         kmerfinder: \$(echo "${kmerfinder_version}")
+        kmerfinderdb: \$(echo "${kmerfinderdb_version}")
     END_VERSIONS
     """
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -83,7 +83,7 @@
                 },
                 "kmerfinderdb": {
                     "type": "string",
-                    "description": "Path to the Kmerfinder bacteria database. For more details, see [Kmerfinder Databases](https://bitbucket.org/genomicepidemiology/kmerfinder_db/src/master/). You can also download precomputed Kmerfinder database (dated 2019/01/08) from https://zenodo.org/records/10458361/files/20190108_kmerfinder_stable_dirs.tar.gz "
+                    "description": "Path to the Kmerfinder bacteria database. For more details, see [Kmerfinder Databases](https://bitbucket.org/genomicepidemiology/kmerfinder_db/src/master/). You can also download precomputed Kmerfinder database (dated 2019/01/08) from https://zenodo.org/records/13447056/files/20190108_kmerfinder_stable_dirs.tar.gz"
                 },
                 "reference_fasta": {
                     "type": "string",
@@ -95,7 +95,7 @@
                 },
                 "ncbi_assembly_metadata": {
                     "type": "string",
-                    "description": "Master file (*.txt) containing a summary of assemblies available in GeneBank or RefSeq. See: https://ftp.ncbi.nlm.nih.gov/genomes/README_assembly_summary.txt"
+                    "description": "Master file (*.txt) containing a summary of assemblies available in GeneBank or RefSeq. See: https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_refseq.txt"
                 }
             }
         },

--- a/subworkflows/local/kmerfinder_subworkflow.nf
+++ b/subworkflows/local/kmerfinder_subworkflow.nf
@@ -33,7 +33,8 @@ workflow KMERFINDER_SUBWORKFLOW {
         .set{ ch_to_kmerfinder }
 
     KMERFINDER (
-        ch_to_kmerfinder
+        ch_to_kmerfinder,    // Channel: [ meta, reads, path_to_kmerfinderdb ]
+        'bacteria'           // Val: 'tax_group'
     )
     ch_kmerfinder_report    = KMERFINDER.out.report
     ch_kmerfinder_json      = KMERFINDER.out.json


### PR DESCRIPTION
<!--
# nf-core/bacass pull request

Many thanks for contributing to nf-core/bacass!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## PR description
This PR attemps to fix corrupted Zenodo Link of Kmerfinder database (fixed version here: https://zenodo.org/records/13447056).

### Command to test it
```
nextflow run main.nf \          
    -profile docker,test \
    --outdir ./results \
    --assembler 'unicycler' \
    --assembly_type 'short' \
    --skip_kmerfinder false \
    --kmerfinderdb 'https://zenodo.org/records/13447056/files/20190108_kmerfinder_stable_dirs.tar.gz' \
    --ncbi_assembly_metadata 'https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_refseq.txt' \
    --skip_annotation -resume
```

Related #155 
