### PR TITLE
Fix long reads polishing input channel and refactor long reads polishing section 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#169](https://github.com/nf-core/bacass/pull/169) Refactored long-reads polishing step.
 - [#167](https://github.com/nf-core/bacass/pull/167) Remove params.save_merged as merged reads are not used in downstream analysis.
 - [#159](https://github.com/nf-core/bacass/pull/159) Updated Kmerfinder module and increased memory.
 - [#150](https://github.com/nf-core/bacass/pull/150) Replace local unicycler module with nf-core module + bump version.
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#169](https://github.com/nf-core/bacass/pull/169) Fixed long reads polishing input channel.
 - [#168](https://github.com/nf-core/bacass/pull/168) Fix wrong metadata in canu input channel.
 - [#163](https://github.com/nf-core/bacass/pull/163) Fixed `params.save_merged` to properly save merged files.
 - [#160](https://github.com/nf-core/bacass/pull/160) Fixed memory issues in KmerFinder, fixed handling of no species detected, and fixed handling of empty fasta files in the prokka/bakkta channel.

--- a/modules/local/medaka/main.nf
+++ b/modules/local/medaka/main.nf
@@ -8,7 +8,7 @@ process MEDAKA {
         'biocontainers/medaka:1.4.3--py38h130def0_0' }"
 
     input:
-    tuple val(meta), file(longreads), file(assembly)
+    tuple val(meta), path(longreads), path(assembly)
 
     output:
     tuple val(meta), path('*_polished_genome.fa')   , emit: assembly
@@ -33,9 +33,11 @@ process MEDAKA {
     medaka_consensus $args \
         -i ${ reads_bgzip_out ?: longreads } \
         -d ${ assembly_bgzip_out ?: assembly } \
-        -o "${prefix}_polished_genome.fa" \
+        -o "${prefix}_out" \
         -t $task.cpus
 
+    mv ${prefix}_out/* .
+    mv consensus.fasta ${prefix}_polished_genome.fa
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         medaka: \$( medaka --version 2>&1 | sed 's/medaka //g' )

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -298,7 +298,7 @@ workflow BACASS {
     //
     // SUBWORKFLOW: Long reads polishing. Uses medaka or Nanopolish (this last requires Fast5 files available in input samplesheet).
     //
-    if ( (params.assembly_type != 'short' && !params.skip_polish) || ( params.assembly_type != 'short' && params.polish_method) ){
+    if ( (params.assembly_type == 'long' && !params.skip_polish) || ( params.assembly_type != 'short' && params.polish_method) ){
         // Set channel for polishing long reads
         ch_for_assembly
             .join( ch_assembly )

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -294,51 +294,64 @@ workflow BACASS {
     }
 
     //
-    // MODULE: Nanopolish, polishes assembly using FAST5 files - should take either miniasm, canu, or unicycler consensus sequence
+    // SUBWORKFLOW: Long reads polishing. Uses medaka or Nanopolish (this last requires Fast5 files available in input samplesheet).
     //
-    if ( !params.skip_polish && params.assembly_type == 'long' && params.polish_method != 'medaka' ) {
+    if ( (params.assembly_type != 'short' && !params.skip_polish) || ( params.assembly_type != 'short' && params.polish_method) ){
+        // Set channel for polishing long reads
         ch_for_assembly
             .join( ch_assembly )
-            .set { ch_for_polish }
-
-        MINIMAP2_POLISH (
-            ch_for_polish.map { meta, sr, lr, fasta -> tuple(meta, lr) },
-            ch_for_polish.map { meta, sr, lr, fasta -> tuple(meta, fasta) },
-            true,
-            false,
-            false
-        )
-        ch_versions = ch_versions.mix(MINIMAP2_POLISH.out.versions)
-
-        SAMTOOLS_INDEX (
-            MINIMAP2_POLISH.out.bam.dump(tag: 'samtools_sort')
-        )
-        ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions)
-
-        ch_for_polish    // tuple val(meta), val(reads), file(longreads), file(assembly)
-            .join( MINIMAP2_POLISH.out.bam )    // tuple val(meta), file(bam)
-            .join( SAMTOOLS_INDEX.out.bai )     // tuple  val(meta), file(bai)
-            .join( ch_fast5 )                   // tuple val(meta), file(fast5)
-            .set { ch_for_nanopolish }          // tuple val(meta), val(reads), file(longreads), file(assembly), file(bam), file(bai), file(fast5)
-
-        // TODO: 'nanopolish index' couldn't be tested. No fast5 provided in test datasets.
-        NANOPOLISH (
-            ch_for_nanopolish.dump(tag: 'into_nanopolish')
-        )
-        ch_versions = ch_versions.mix(NANOPOLISH.out.versions)
-    }
-
-    //
-    // MODULE: Medaka, polishes assembly - should take either miniasm, canu, or unicycler consensus sequence
-    //
-    if ( !params.skip_polish && params.assembly_type == 'long' && params.polish_method == 'medaka' ) {
-        ch_for_assembly
-            .join( ch_assembly )
-            .map { meta, sr, lr, assembly -> tuple(meta, lr, assembly) }
-            .set { ch_for_medaka }
-
-        MEDAKA ( ch_for_medaka.dump(tag: 'into_medaka') )
-        ch_versions = ch_versions.mix(MEDAKA.out.versions)
+            .set { ch_polish_long } // channel: [ val(meta), path(sr), path(lr), path(fasta) ]
+        if (params.polish_method == 'medaka'){
+            //
+            // MODULE: Medaka, polishes assembly - should take either miniasm, canu, or unicycler consensus sequence
+            //
+            ch_polish_long
+                .map { meta, sr, lr, fasta -> tuple(meta, lr, fasta) }
+                .set { ch_for_medaka }
+            MEDAKA ( ch_for_medaka.dump(tag: 'into_medaka') )
+            ch_assembly = ch_assembly.mix( MEDAKA.out.assembly )
+            ch_versions = ch_versions.mix(MEDAKA.out.versions)
+        } else if (params.polish_method == 'nanopolish') {
+            //
+            // MODULE: Nanopolish, polishes assembly using FAST5 files
+            //
+            if (!ch_fast5){
+                log.error "ERROR: FAST5 files are required for Nanopolish but none were provided. Please supply FAST5 files or choose another polishing method. Available options are: medaka, nanopolish"
+            } else {
+                //
+                // MODULE: Minimap2 polish
+                //
+                MINIMAP2_POLISH (
+                    ch_polish_long.map { meta, sr, lr, fasta -> tuple(meta, lr) },
+                    ch_polish_long.map { meta, sr, lr, fasta -> tuple(meta, fasta) },
+                    true,
+                    false,
+                    false
+                )
+                ch_versions = ch_versions.mix(MINIMAP2_POLISH.out.versions)
+                //
+                // MODULE: Samtools index
+                //
+                SAMTOOLS_INDEX (
+                    MINIMAP2_POLISH.out.bam.dump(tag: 'samtools_sort')
+                )
+                ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions)
+                //
+                // MODULE: Nanopolish
+                //
+                ch_polish_long                         // tuple val(meta), val(reads), file(longreads), file(assembly)
+                    .join( MINIMAP2_POLISH.out.bam )  // tuple val(meta), file(bam)
+                    .join( SAMTOOLS_INDEX.out.bai )   // tuple  val(meta), file(bai)
+                    .join( ch_fast5 )                 // tuple val(meta), file(fast5)
+                    .set { ch_for_nanopolish }        // tuple val(meta), val(reads), file(longreads), file(assembly), file(bam), file(bai), file(fast5)
+                // TODO: 'nanopolish index' couldn't be tested. No fast5 provided in test datasets.
+                NANOPOLISH (
+                    ch_for_nanopolish.dump(tag: 'into_nanopolish')
+                )
+                ch_assembly = ch_assembly.mix( NANOPOLISH.out.assembly )
+                ch_versions = ch_versions.mix( NANOPOLISH.out.versions )
+            }
+        }
     }
 
     //

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -240,7 +240,7 @@ workflow BACASS {
     //
     // MODULE: Miniasm, genome assembly, long reads
     //
-    if ( params.assembler == 'miniasm' ) {
+    if ( params.assembly_type != 'short' && params.assembler == 'miniasm' ) {
         MINIMAP2_ALIGN (
             ch_for_assembly.map{ meta,sr,lr -> tuple(meta,lr) },
             [[:],[]],
@@ -280,6 +280,8 @@ workflow BACASS {
         )
         ch_assembly = ch_assembly.mix( RACON.out.improved_assembly.dump(tag: 'miniasm') )
         ch_versions = ch_versions.mix( RACON.out.versions )
+    } else if (params.assembly_type == 'short' && params.assembler == 'miniasm') {
+        exit("Selected assembler ${params.assembler} cannot run on short reads")
     }
 
     //

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -302,8 +302,8 @@ workflow BACASS {
             .set { ch_for_polish }
 
         MINIMAP2_POLISH (
-            ch_for_polish.map { meta, sr, lr, fasta -> tuple(meta, lr)  },
-            ch_for_polish.map { meta, sr, lr, fasta -> fasta  },
+            ch_for_polish.map { meta, sr, lr, fasta -> tuple(meta, lr) },
+            ch_for_polish.map { meta, sr, lr, fasta -> tuple(meta, fasta) },
             true,
             false,
             false


### PR DESCRIPTION
<!--
# nf-core/bacass pull request

Many thanks for contributing to nf-core/bacass!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## PR Description

This PR fixes a wrong channel input for MINIMAP_ALIGN module (#165 )

The logic for long read polishing has been updated as follows:
- Long read polishing is now restricted to `assembly_type` == `long` (hybrid mode uses different tools and a separate polishing strategy).
- Fixed: The polished genome from the long reads (assembly_type == long) is now the default candidate for downstream analysis.


(Closes #165 )