### PR TITLE
fixed matrix.test_name in linting and missing features from template 3.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,6 @@ jobs:
             profile: "conda"
           - isMaster: false
             profile: "singularity"
-        parameters:
-          - "test"
-          - "test_long"
-          - "test_long_miniasm"
-          - "test_hybrid"
-          - "test_dfast"
 
     steps:
       - name: Check out pipeline code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
           - "singularity"
         test_name:
           - "test"
+          - "test_long"
+          - "test_long_miniasm"
+          - "test_hybrid"
+          - "test_dfast"
         isMaster:
           - ${{ github.base_ref == 'master' }}
         # Exclude conda and singularity on dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#179](https://github.com/nf-core/bacass/pull/179) Fixed matrix.test_name in linting and missing features from template 3.0.2.
 - [#178](https://github.com/nf-core/bacass/pull/178) Fixed bakta running only for one sample.
 - [#169](https://github.com/nf-core/bacass/pull/169) Fixed long reads polishing input channel.
 - [#168](https://github.com/nf-core/bacass/pull/168) Fix wrong metadata in canu input channel.

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -19,7 +19,6 @@
                 "anyOf": [
                     {
                         "type": ["string", "null"],
-                        "exists": true,
                         "pattern": "^(\\S+\\.f(ast)?q\\.gz|NA)$"
                     },
                     {
@@ -33,7 +32,6 @@
                 "anyOf": [
                     {
                         "type": ["string", "null"],
-                        "exists": true,
                         "pattern": "^(\\S+\\.f(ast)?q\\.gz|NA)$"
                     },
                     {
@@ -47,7 +45,6 @@
                 "anyOf": [
                     {
                         "type": ["string", "null"],
-                        "exists": true,
                         "pattern": "^(\\S+\\.f(ast)?q\\.gz|NA)$"
                     },
                     {
@@ -61,7 +58,6 @@
                 "anyOf": [
                     {
                         "type": ["string", "null"],
-                        "exists": true,
                         "pattern": "^(\\/[\\S\\s]*|NA)$"
                     },
                     {

--- a/conf/test_dfast.config
+++ b/conf/test_dfast.config
@@ -10,14 +10,18 @@
 ----------------------------------------------------------------------------------------
 */
 
+// Limit resources so that this can run on GitHub Actions
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Test_dfast profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
-
-    // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = 6.GB
-    max_time   = 6.h
 
     // Input data
     input = params.pipelines_testdata_base_path + 'bacass/bacass_short.tsv'

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -10,6 +10,15 @@
 ----------------------------------------------------------------------------------------
 */
 
+// Limit resources so that this can run on GitHub Actions
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -10,14 +10,18 @@
 ----------------------------------------------------------------------------------------
 */
 
+// Limit resources so that this can run on GitHub Actions
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
-
-    // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = 6.GB
-    max_time   = 6.h
 
     // Input data
     input = params.pipelines_testdata_base_path + 'bacass/bacass_hybrid.tsv'

--- a/conf/test_hybrid_dragonflye.config
+++ b/conf/test_hybrid_dragonflye.config
@@ -10,14 +10,18 @@
 ----------------------------------------------------------------------------------------
 */
 
+// Limit resources so that this can run on GitHub Actions
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Test hybrid-dragonflye profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
-
-    // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = 6.GB
-    max_time   = 6.h
 
     // Input data
     input = params.pipelines_testdata_base_path + 'bacass/bacass_hybrid_dragonflye.tsv'

--- a/conf/test_long.config
+++ b/conf/test_long.config
@@ -10,14 +10,18 @@
 ----------------------------------------------------------------------------------------
 */
 
+// Limit resources so that this can run on GitHub Actions
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Test_long profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
-
-    // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = 6.GB
-    max_time   = 6.h
 
     // Input data
     input = params.pipelines_testdata_base_path + 'bacass/bacass_long_miniasm.tsv'

--- a/conf/test_long_dragonflye.config
+++ b/conf/test_long_dragonflye.config
@@ -9,6 +9,14 @@
 
 ----------------------------------------------------------------------------------------
 */
+// Limit resources so that this can run on GitHub Actions
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
 
 params {
     config_profile_name        = 'Test_long_dragonfyle profile'

--- a/conf/test_long_miniasm.config
+++ b/conf/test_long_miniasm.config
@@ -10,14 +10,18 @@
 ----------------------------------------------------------------------------------------
 */
 
+// Limit resources so that this can run on GitHub Actions
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Test_long_miniasm profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
-
-    // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = 6.GB
-    max_time   = 6.h
 
     // Input data
     input = params.pipelines_testdata_base_path + 'bacass/bacass_long_miniasm.tsv'


### PR DESCRIPTION
<!--
# nf-core/bacass pull request

Many thanks for contributing to nf-core/bacass!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## PR description

I incorrectly incorporated the test names in the GitHub CI after the nf-core [template update](https://github.com/nf-core/bacass/pull/176). As a result, only the `test` profile was running repeatedly. This update should fix the issue and ensure the correct tests are executed.

In addition, config test missed to incorporate [resourceLimits](url) feature in test profiles ([see 'Whats new 3.0.0'](https://nf-co.re/blog/2024/tools-3_0_0)). 