### PR TITLE
Replace download_reference.py with NCBI Datasets API implementation (removes `assembly_summary_refseq.txt` dependency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#249] (https://github.com/nf-core/bacass/pull/249) Replace `download_reference.py` with NCBI Datasets API implementation (`removes assembly_summary_refseq.txt` dependency).
 - [#247](https://github.com/nf-core/bacass/pull/247) Update modules: unicycler (to 0.5.1) and dragonflye (to 1.2.1)
 - [#239](https://github.com/nf-core/bacass/pull/239) Add protein FASTA file as an optional parameter to be used by PROKKA to annotate the assembly. Using `--prokka_proteins` parameter to point to the protein FASTA file.
 - [#221](https://github.com/nf-core/bacass/pull/221) update fastq_trim_fastp_fastqc subworkflow and its modules.

--- a/bin/download_reference.py
+++ b/bin/download_reference.py
@@ -1,160 +1,151 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
-=============================================================
-HEADER
-=============================================================
-INSTITUTION: BU-ISCIII
-AUTHOR: Guillermo J. Gorines Cordero
-EDITED BY: Daniel VM
-VERSION: 0.1
-CREATED: Early 2022
-REVISED: 18-2-2022
-EDITED: 14-11-2023
-DESCRIPTION: 20-05-2024
-    Given a file with the kmerfinder results and frequencies (probably
-    created by find_common_reference.py), and the NCBI assembly sheet,
-    download the top-reference genome, gff and protein files from
-    the NCBI ftp.
+download_reference.py — replacement version
+==========================================
+Fetches genome FASTA, GFF and protein FASTA for the *top* accession
+reported by `find_common_reference.py`, using the public NCBI Datasets
+REST API (v2alpha). This eliminates the need for a local
+`assembly_summary_refseq.txt` file.
 
-INPUT:
-    -FILE: file containing the ranking of references from kmerfinder created by the script find_common_references
-    -REFERENCE: file with the NCBI reference list
-    -OUTDIR: name of the output dir
+Inputs
+------
+* **--file**     / **-f** : Path to `references_found.tsv` (first column must be the assembly accession, e.g. *GCF_000001405.40*).
+* **--out_dir**  / **-o** : Directory where the compressed outputs will be written (created if necessary).
+* **--reference**: *Deprecated, ignored*. Present only for backwards CLI‑compatibility with the previous script.
 
-OUTPUT:
-    - *_fna.gz: file with the top-reference genome
-    - *_gff.gz: file with the top-reference gff
-    - *_protein.gz: file with the top-reference proteins
+Outputs (written inside *out_dir*)
+---------------------------------
+* `<accession>_genomic.fna.gz`
+* `<accession>_genomic.gff.gz`
+* `<accession>.winner` – single‑line text file with the winning accession
 
-USAGE:
-    python download_reference.py
-    -file [FILE]
-    -reference [REFERENCE]
-    -out_dir [OUTDIR]
-
-REQUIREMENTS:
-    -Python >= 3.6
-    -Python wget
-
-DISCLAIMER:
-    This script has been designed for the assembly pipeline of BU-ISCIII.
-    Feel free to use it at will, however we dont guarantee its success
-    outside its purpose.
-================================================================
-END_OF_HEADER
-================================================================
+The compressed file names match those produced by the original
+implementation, so downstream workflow steps continue to work
+unchanged.
 """
+from __future__ import annotations
 
-import sys
 import argparse
-import os
+import gzip
+import shutil
+import sys
+import urllib3
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from typing import Dict, List
 
-# import wget
-import requests
+# -----------------------------------------------------------------------------
+# Annotation request combinations (most → least detailed)
+# -----------------------------------------------------------------------------
+_ANNO_SETS: List[List[str]] = [
+    ["GENOME_FASTA", "GENOME_GFF", "PROTEIN_FASTA"],
+    ["GENOME_FASTA", "GENOME_GFF"],
+    ["GENOME_FASTA"],
+]
+
+# Mapping from file suffix inside the dataset archive to output suffix
+_SUFFIX_MAP: Dict[str, str] = {
+    "_genomic.fna": "_genomic.fna.gz",
+    "_genomic.gff": "_genomic.gff.gz",
+    "_protein.faa": "_protein.faa.gz",
+}
 
 
-# TODO: Generate report
-def parse_args(args=None):
-    Description = "download the reference files \
-        (fna, faa, gff)from the reference NCBI file."
-    Epilog = """Usage example: \
-        python download_reference.py \
-        -file <file with the references created by find_common_reference> \
-        -reference <file from the NCBI with all bacterial references> \
-        -out_dir <output directory>"""
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
 
-    parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
-    parser.add_argument(
-        "-file", help="File containing the ranking of references from kmerfinder."
+def _datasets_url(acc: str, anno_types: List[str]) -> str:
+    anno_qs = "&".join(f"include_annotation_type={t}" for t in anno_types)
+    return (
+        "https://api.ncbi.nlm.nih.gov/datasets/v2alpha/genome/accession/"
+        f"{acc}/download?{anno_qs}&hydrated=FULLY_HYDRATED"
     )
-    parser.add_argument(
-        "-reference",
-        help="File containing the paths to bacterial references. See example in: https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_refseq.txt",
+
+
+def _fetch_dataset(acc: str) -> BytesIO:
+    """Try downloading with fallback annotation sets; return ZIP bytes."""
+    http = urllib3.PoolManager()
+    for anno in _ANNO_SETS:
+        url = _datasets_url(acc, anno)
+        resp = http.request("GET", url, preload_content=False)
+        if resp.status == 200:
+            resp.auto_close = False
+            return BytesIO(resp.data)
+        elif resp.status == 400:
+            # Try next (simpler) request
+            continue
+        else:
+            raise RuntimeError(f"NCBI API returned HTTP {resp.status} for {acc}")
+    raise RuntimeError(
+        f"NCBI API cannot provide any dataset (FASTA even) for accession {acc}."
     )
-    parser.add_argument("-out_dir", help="Output directory.")
-
-    return parser.parse_args(args)
 
 
-def download_references(file, reference, out_dir):
-    """
-    Downloads the top reference from the NCBI database
-    """
+def _winner_from_tsv(tsv_path: Path) -> str:
+    with tsv_path.open() as fh:
+        for line in fh:
+            if line.startswith("#") or not line.strip():
+                continue
+            return line.split("\t")[0]
+    raise RuntimeError(f"No accession found in {tsv_path}")
 
-    reference_ends = ["_genomic.fna.gz", "_protein.faa.gz", "_genomic.gff.gz"]
 
-    # extract the most common reference from file
-    with open(file) as infile:
-        infile = infile.readlines()
-        infile = [
-            item.replace("\n", "").split("\t")
-            for item in infile
-            if not item.startswith("#")
-        ]
-        top_reference = infile[0][0]
+def _extract_files(zip_bytes: BytesIO, acc: str, out_dir: Path):
+    with zipfile.ZipFile(zip_bytes) as zf:
+        zf.extractall(out_dir)
 
-    with open(str(top_reference) + ".winner", "w") as topref:
-        topref.write(top_reference)
+    data_root = out_dir / "ncbi_dataset" / "data" / acc
+    if not data_root.exists():
+        raise RuntimeError(f"Unexpected archive structure – cannot find {data_root}")
 
-    # create the outdir (do nothing if already there)
+    for in_suf, out_suf in _SUFFIX_MAP.items():
+        matches = list(data_root.rglob(f"*{in_suf}"))
+        if not matches:
+            # If the file type wasn't requested (due to fallback), just skip
+            continue
+        src_path = matches[0]
+        dest_path = out_dir / f"{acc}{out_suf}"
+        with src_path.open("rb") as src, gzip.open(dest_path, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+def _parse_cli(argv: list[str] | None = None):
+    p = argparse.ArgumentParser(
+        description="Download reference assembly via NCBI Datasets REST API with smart fallbacks",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("-f", "--file", required=True, help="TSV from find_common_reference.py")
+    p.add_argument("-o", "--out_dir", required=True, help="Directory to place outputs")
+    return p.parse_args(argv)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None):
+    args = _parse_cli(argv)
+    out_dir = Path(args.out_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    acc = _winner_from_tsv(Path(args.file))
+    (out_dir / f"{acc}.winner").write_text(acc + "\n")
+
+    zip_bytes: BytesIO | None = None
     try:
-        os.mkdir(out_dir)
-    except FileExistsError:
-        pass
+        zip_bytes = _fetch_dataset(acc)
+        _extract_files(zip_bytes, acc, out_dir)
+    finally:
+        if zip_bytes is not None:
+            zip_bytes.close()
 
-    # open the reference and find the reference
-    with open(reference) as inref:
-        inref = inref.readlines()
-        inref = [
-            item.replace("\n", "").split("\t")
-            for item in inref
-            if not item.startswith("#")
-        ]
-
-        # Initialize an empty list to store the URLs
-        dir_url = []
-
-        # Iterate over each row in the inref
-        for row in inref:
-            # Construct the ref_query using assembly_accession and asm_name
-            assembly_accession = row[0]
-            asm_name = row[15]
-            ref_query = f"{assembly_accession}_{asm_name}"
-
-            # Check if ref_query matches the search value
-            if top_reference in ref_query:
-                # make url  # Append the 20th element of the row to the URL list:
-                assembly_url = row[19] + "/" + ref_query
-                dir_url.append(assembly_url)
-
-        if len(dir_url) == 0:
-            print(
-                "No assemblies responding to the top reference: ",
-                top_reference,
-                " were found",
-            )
-            sys.exit(1)
-
-        dir_url = str(dir_url[0])
-
-    # get url and reference file
-    for r_end in reference_ends:
-        out_file = out_dir + "/" + top_reference + r_end
-        file_url = dir_url + r_end
-        print(file_url)
-
-        # wget.download(file_url, out_file)
-        response = requests.get(file_url, stream=True)
-        with open(out_file, "wb") as out:
-            for chunk in response.iter_content(chunk_size=8192):
-                out.write(chunk)
-
-    return
-
-
-def main(args=None):
-    args = parse_args(args)
-    download_references(args.file, args.reference, args.out_dir)
+    print(f"[INFO] Downloaded reference for {acc} → {out_dir}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -27,5 +27,4 @@ params {
     input                       = params.pipelines_testdata_base_path + 'bacass/bacass_full.tsv'
     kraken2db                   = 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_8gb_20210517.tar.gz'
     kmerfinderdb                = 'https://zenodo.org/records/13447056/files/20190108_kmerfinder_stable_dirs.tar.gz'
-    ncbi_assembly_metadata      = 'https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_refseq.txt'
 }

--- a/modules/local/kmerfinder/download_reference/main.nf
+++ b/modules/local/kmerfinder/download_reference/main.nf
@@ -11,8 +11,8 @@ process KMERFINDER_DOWNLOAD_REFERENCE {
     tuple val(refmeta), path(reports,  stageAs: 'reports/*')
 
     output:
-    tuple val(refmeta), path("ncbi_dataset/data/*.fna") , emit: fna
-    tuple val(refmeta), path("ncbi_dataset/data/*.gff") , emit: gff
+    tuple val(refmeta), path("ncbi_dataset/data/*/*.fna") , emit: fna
+    tuple val(refmeta), path("ncbi_dataset/data/*/*.gff") , emit: gff
     tuple val(refmeta), path("references_found.tsv")    , emit: references_tsv
     tuple val(refmeta), path("*.winner")                , emit: winner
     path "versions.yml"                                 , emit: versions
@@ -26,8 +26,8 @@ process KMERFINDER_DOWNLOAD_REFERENCE {
 
     ## Download the winner reference genome from the ncbi database
     download_reference.py \\
-        -file references_found.tsv \\
-        -out_dir .
+        -f references_found.tsv \\
+        -o .
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/kmerfinder/download_reference/main.nf
+++ b/modules/local/kmerfinder/download_reference/main.nf
@@ -9,15 +9,13 @@ process KMERFINDER_DOWNLOAD_REFERENCE {
 
     input:
     tuple val(refmeta), path(reports,  stageAs: 'reports/*')
-    path(ncbi_metadata_db)
 
     output:
-    tuple val(refmeta), path("*.fna.gz")              , emit: fna
-    tuple val(refmeta), path("*.gff.gz")              , emit: gff
-    tuple val(refmeta), path("*.faa.gz")              , emit: faa
-    tuple val(refmeta), path("references_found.tsv")  , emit: references_tsv
-    tuple val(refmeta), path("*.winner")              , emit: winner
-    path "versions.yml"                               , emit: versions
+    tuple val(refmeta), path("ncbi_dataset/data/*.fna") , emit: fna
+    tuple val(refmeta), path("ncbi_dataset/data/*.gff") , emit: gff
+    tuple val(refmeta), path("references_found.tsv")    , emit: references_tsv
+    tuple val(refmeta), path("*.winner")                , emit: winner
+    path "versions.yml"                                 , emit: versions
 
     script:
     """
@@ -29,7 +27,6 @@ process KMERFINDER_DOWNLOAD_REFERENCE {
     ## Download the winner reference genome from the ncbi database
     download_reference.py \\
         -file references_found.tsv \\
-        -reference $ncbi_metadata_db \\
         -out_dir .
 
     cat <<-END_VERSIONS > versions.yml

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,7 +25,6 @@ params {
     kmerfinderdb                    = ''
     reference_fasta                 = ''
     reference_gff                   = ''
-    ncbi_assembly_metadata          = ''
 
     // Assembly parameters
     assembler                       = 'unicycler'   // Allowed: ['unicycler', 'canu', 'miniasm', 'dragonflye']

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -118,10 +118,6 @@
                 "reference_gff": {
                     "type": "string",
                     "description": "Reference GFF file."
-                },
-                "ncbi_assembly_metadata": {
-                    "type": "string",
-                    "description": "Master file (*.txt) containing a summary of assemblies available in GeneBank or RefSeq. See: https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_refseq.txt"
                 }
             }
         },

--- a/subworkflows/local/kmerfinder_summary_download/main.nf
+++ b/subworkflows/local/kmerfinder_summary_download/main.nf
@@ -16,7 +16,6 @@ workflow KMERFINDER_SUMMARY_DOWNLOAD {
 
     // Prepare kmerfinder database
     ch_kmerfinderdb           = file(params.kmerfinderdb, checkIfExists: true)
-    ch_ncbi_assembly_metadata = file(params.ncbi_assembly_metadata, checkIfExists: true)
 
     if ( ch_kmerfinderdb.name.endsWith('.gz') ) {
         UNTAR ( [[ id: ch_kmerfinderdb.getSimpleName() ], ch_kmerfinderdb] )
@@ -62,8 +61,7 @@ workflow KMERFINDER_SUMMARY_DOWNLOAD {
     KMERFINDER_DOWNLOAD_REFERENCE (
         ch_reports_byreference
             .map{ specie, meta, report_txt, fasta-> tuple(specie, report_txt) }
-            .filter{ specie, report_txt -> specie != "Unknown Species" },
-        ch_ncbi_assembly_metadata
+            .filter{ specie, report_txt -> specie != "Unknown Species" }
     )
     ch_versions = ch_versions.mix(KMERFINDER_DOWNLOAD_REFERENCE.out.versions)
 

--- a/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
@@ -173,11 +173,10 @@ def validateInputParameters() {
 
     // Check kmerfinder dependencies
     if (!params.skip_kmerfinder) {
-        if (!params.kmerfinderdb || !params.ncbi_assembly_metadata) {
+        if (!params.kmerfinderdb ) {
             def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-                "  Kmerfinder database and NCBI assembly metadata not provided.\n" +
-                "  Please specify the '--kmerfinderdb' and '--ncbi_assembly_metadata' parameters.\n" +
-                "  Both are required to run Kmerfinder.\n" +
+                "  Kmerfinder database not provided.\n" +
+                "  Please specify the '--kmerfinderdb'  parameter to provide the necessary database.\n"
                 "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
             error(error_string)
         }


### PR DESCRIPTION
…e in kmerfinder

<!--
# nf-core/bacass pull request

Many thanks for contributing to nf-core/bacass!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## PR description

As discussed here (#172 ), it has be implemented new strategy to remove the `ncbi_assembly_metadata` parameter dependency by using NCBI Datasets API to download genomes.

Closes #172 
