### PR TITLE
Activate by default all assemblers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#263](https://github.com/nf-core/bacass/pull/263) Update Template to 3.5.1
 - [#264](https://github.com/nf-core/bacass/pull/264) Follow Nextflow strict syntax
 - [#270](https://github.com/nf-core/bacass/pull/270) `--assembler` accepts now also a comma separated list of available assemblers that are all executed in parallel on samples and compared via the QUAST report.
+- [#272](https://github.com/nf-core/bacass/pull/272) All available assemblers are now active by default.
 
 ### `Added`
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,7 @@ This pipeline is primarily for bacterial assembly of next-generation sequencing 
 
 For users that only have Nanopore data, the pipeline quality trims these using [PoreChop](https://github.com/rrwick/Porechop) or filter long reads by quality using [Filtlong](https://github.com/rrwick/Filtlong) and assesses basic sequencing QC utilizing [NanoPlot](https://github.com/wdecoster/NanoPlot) and [PycoQC](https://github.com/a-slide/pycoQC). Contamination of the assembly is checked using [Kraken2](https://ccb.jhu.edu/software/kraken2/) and [Kmerfinder](https://bitbucket.org/genomicepidemiology/kmerfinder/src/master/) to verify sample purity.
 
-The pipeline can then perform long read assembly utilizing [Unicycler](https://github.com/rrwick/Unicycler), [Miniasm](https://github.com/lh3/miniasm) in combination with [Racon](https://github.com/isovic/racon), [Canu](https://github.com/marbl/canu), [Flye](https://github.com/fenderglass/Flye), [Raven](https://github.com/lbcb-sci/raven), a combination of several assemblers with [Autocycler](https://github.com/rrwick/Autocycler), or the [Dragonflye](https://github.com/rpetit3/dragonflye)(\*) pipeline. Long reads assembly can be polished using [Medaka](https://github.com/nanoporetech/medaka) or [NanoPolish](https://github.com/jts/nanopolish) with Fast5 files.
-
-> [!NOTE]
-> Dragonflye is a comprehensive pipeline designed for genome assembly of Oxford Nanopore Reads. It facilitates the utilization of Flye (default), Miniasm, and Raven assemblers, along with Racon (default) and Medaka polishers. For more information, visit the [Dragonflye GitHub](https://github.com/rpetit3/dragonflye) repository.
+The pipeline can then perform long read assembly utilizing [Unicycler](https://github.com/rrwick/Unicycler), [Miniasm](https://github.com/lh3/miniasm) in combination with [Racon](https://github.com/isovic/racon), [Canu](https://github.com/marbl/canu), [Flye](https://github.com/fenderglass/Flye), [Raven](https://github.com/lbcb-sci/raven), a combination of several assemblers with [Autocycler](https://github.com/rrwick/Autocycler), and the [Dragonflye](https://github.com/rpetit3/dragonflye)(\*) pipeline. Long reads assembly can be polished using [Medaka](https://github.com/nanoporetech/medaka) or [NanoPolish](https://github.com/jts/nanopolish) with Fast5 files.
 
 ### Hybrid Assembly
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -28,6 +28,7 @@ params {
     // some extra args to speed tests up
     prokka_args     = " --fast"
     assembly_type   = 'short'
+    assembler       = 'unicycler'
     skip_pycoqc     = true
     skip_kraken2    = true
     skip_kmerfinder = true

--- a/conf/test_dfast.config
+++ b/conf/test_dfast.config
@@ -29,6 +29,7 @@ params {
     // some extra args to speed tests up
     annotation_tool = 'dfast'
     assembly_type   = 'short'
+    assembler       = 'unicycler'
     skip_pycoqc     = true
     skip_kraken2    = true
     skip_kmerfinder = true

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -17,6 +17,7 @@ params {
     // Input data for full size test
     input                       = params.pipelines_testdata_base_path + 'bacass/bacass_full.tsv'
     assembly_type               = 'short'
+    assembler                   = 'unicycler'
     kraken2db                   = 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_8gb_20210517.tar.gz'
     kmerfinderdb                = 'https://zenodo.org/records/13447056/files/20190108_kmerfinder_stable_dirs.tar.gz'
     unicycler_args              = '--mode bold --kmers 51 --spades_options " --only-assembler"'

--- a/conf/test_hybrid.config
+++ b/conf/test_hybrid.config
@@ -28,6 +28,7 @@ params {
 
     // some extra args to speed tests up
     assembly_type   ='hybrid'
+    assembler       = 'unicycler'
     prokka_args     =" --fast"
     skip_kraken2    = true
     skip_kmerfinder = true

--- a/conf/test_liftoff.config
+++ b/conf/test_liftoff.config
@@ -33,6 +33,7 @@ params {
     // some extra args to speed tests up
     annotation_tool = 'liftoff'
     assembly_type   = 'short'
+    assembler       = 'unicycler'
     skip_pycoqc     = true
     skip_kraken2    = true
     skip_kmerfinder = true

--- a/conf/test_long.config
+++ b/conf/test_long.config
@@ -29,6 +29,7 @@ params {
     // some extra args to speed tests up
     prokka_args     = " --fast"
     assembly_type   = 'long'
+    assembler       = 'unicycler'
     skip_polish     = true
     skip_kraken2    = true
     skip_kmerfinder = true

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,6 +80,18 @@ outdir: './results/'
 
 You can also generate such `YAML`/`JSON` files via [nf-core/launch](https://nf-co.re/launch).
 
+### Choosing the right assembler
+
+Assemblers have often specific biases originating from their specific implementation. Assembler performance is often sample and context dependent. Therefore, it can be of advantage to compare the outcome of several tools.
+
+This pipeline integrates multiple assembler tools that are all activated by default, allowing a comparison and choice based on the results. However, that can lead to unwanted overhead. The assemblers applied to the data can be restricted with the [--assembler](https://nf-co.re/bacass/parameters/#assembler) parameter.
+
+> [!TIP]
+> Autocycler uses several long-read assemblers and combines their results, reducing assembler-specific biases. The assemblers used for Autocycler can be restricted with the [--autocycler_assemblers](https://nf-co.re/bacass/parameters#autocycler_assemblers) parameter.
+
+> [!NOTE]
+> Dragonflye is a comprehensive pipeline designed for genome assembly of Oxford Nanopore Reads. It facilitates the utilization of Flye (default), Miniasm, and Raven assemblers, along with Racon (default) and Medaka polishers. For more information, visit the [Dragonflye GitHub](https://github.com/rpetit3/dragonflye) repository.
+
 ### Updating the pipeline
 
 When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,13 +27,13 @@ params {
     reference_gff                   = ''
 
     // Assembly parameters
-    assembler                       = 'unicycler'   // Allowed: comma separated list of available assembler
+    assembler                       = 'autocycler,canu,dragonflye,flye,miniasm,unicycler,raven'  // Allowed: comma separated list of available assembler
     assembly_type                   = null       // Allowed: ['short', 'long', 'hybrid'] (hybrid works only with Unicycler)
     unicycler_args                  = ""
     canu_mode                       = '-nanopore'   // Allowed: ['-pacbio', '-nanopore', '-pacbio-hifi']
     canu_args                       = ''            // Default no extra options, can be adjusted by the user
     dragonflye_args                 = ''
-    autocycler_assemblers           = 'canu,flye,raven'
+    autocycler_assemblers           = 'canu,flye,miniasm,raven'
     autocycler_subsample_count      = 4
     autocycler_subsample_mindepth   = 25
     autocycler_cluster_args         = ''

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -130,7 +130,7 @@
             "properties": {
                 "assembler": {
                     "type": "string",
-                    "default": "unicycler",
+                    "default": "autocycler,canu,dragonflye,flye,miniasm,unicycler,raven",
                     "fa_icon": "fas fa-puzzle-piece",
                     "description": "The assembler(s) to use for assembly.",
                     "help_text": "Use the appropriate assembler(s) according to the chosen assembly_type. Can be one or multiple of the available assemblers (e.g. unicycler, canu, miniasm, dragonflye, autocycler, raven, flye, ...) as comma separated string (e.g. `-- assembler \"canu,flye,autocycler\"`)."
@@ -165,7 +165,7 @@
                 },
                 "autocycler_assemblers": {
                     "type": "string",
-                    "default": "canu,flye,raven",
+                    "default": "canu,flye,miniasm,raven",
                     "description": "What assemblers to use for autocycler",
                     "help_text": "Comma separated string of assemblers. For example 'canu,flye,raven'. Allowed is any subset and combination of canu, flye, raven, miniasm ..."
                 },

--- a/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
@@ -241,7 +241,7 @@ def validateInputParameters() {
     if ( params.assembler.tokenize(",").contains("autocycler") ){
         if ( params.autocycler_assemblers.tokenize(",").findAll { e -> autocycler_compatible_assemblers.contains( e ) }.size() != params.autocycler_assemblers.tokenize(",").size() ) {
             def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-            "  Incompatible assemblers for Atocycler specified.\n" +
+            "  Incompatible assemblers for Autocycler specified.\n" +
             "  Please use for '--autocycler_assemblers' a comma separated list of compatible longread assemblers.\n" +
             "  Compatible assemblers: ${autocycler_compatible_assemblers.join(", ")}\n" +
             "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
@@ -223,7 +223,7 @@ def validateInputParameters() {
 
     // Check that assemblers are chosen correctly
     String[] compatible_assemblers = [
-        "canu","miniasm","raven","flye","autocycler","unicycler","dragonflye"
+        "autocycler","canu","dragonflye","flye","miniasm","raven","unicycler"
     ]
     if ( params.assembler.tokenize(",").findAll { e -> compatible_assemblers.contains( e ) }.size() != params.assembler.tokenize(",").size() ) {
         def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
@@ -236,7 +236,7 @@ def validateInputParameters() {
 
     // Check that assemblers for Autocycler are chosen correctly
     String[] autocycler_compatible_assemblers = [
-        "canu","miniasm","raven","flye"
+        "canu","flye","miniasm","raven"
     ]
     if ( params.assembler.tokenize(",").contains("autocycler") ){
         if ( params.autocycler_assemblers.tokenize(",").findAll { e -> autocycler_compatible_assemblers.contains( e ) }.size() != params.autocycler_assemblers.tokenize(",").size() ) {

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -39,6 +39,7 @@ include { KRAKEN2_KRAKEN2 as KRAKEN2            } from '../modules/nf-core/krake
 include { KRAKEN2_KRAKEN2 as KRAKEN2_LONG       } from '../modules/nf-core/kraken2/kraken2'
 include { QUAST                                 } from '../modules/nf-core/quast'
 include { QUAST as QUAST_BYREFSEQID             } from '../modules/nf-core/quast'
+include { QUAST as QUAST_BYSAMPLE               } from '../modules/nf-core/quast'
 include { BUSCO_BUSCO                           } from '../modules/nf-core/busco/busco/main'
 include { GUNZIP                                } from '../modules/nf-core/gunzip'
 include { PROKKA                                } from '../modules/nf-core/prokka'
@@ -695,6 +696,25 @@ workflow BACASS {
         .map{ consensus -> tuple([id:'report'], consensus) }
         .set{ ch_to_quast }
 
+    // First, check if there are multiple distinct samples
+    ch_assembly
+        .map { meta, _consensus -> meta.sample } // Extract sample value
+        .unique()                                // Get only distinct values
+        .collect()                               // Collect all distinct values
+        .filter { sample -> sample.size() > 1 }  // Only proceed if more than 1 distinct value
+        .flatMap { sample -> sample }            // Emit each distinct value separately
+        .set{ ch_multisamples }
+    // If there are multiple samples, make sure they have multiple assemblies
+    ch_assembly
+        .map { meta, file -> [meta.sample, meta, file] }
+        .combine(ch_multisamples)                                                          // When ch_multisamples is empty, nothing will be forwarded
+        .filter { sample_name, meta, files, valid_sample -> sample_name == valid_sample }  // The previous step produced too many combinations, reduce to genuine entries
+        .map { sample_name, metas, files, valid_sample -> [sample_name, metas, files] }
+        .groupTuple(by: 0) // Group by samples
+        .map { sample_name, _meta, files -> [ [id: sample_name], files ] } // Drop meta information
+        .filter { meta, files -> files.size() > 1 } // Only keep samples that have several assemblies
+        .set { ch_to_quast_bysample }
+
     if(params.skip_kmerfinder){
         QUAST(
             ch_to_quast,
@@ -702,10 +722,20 @@ workflow BACASS {
             params.reference_gff ? [[:], reference_gff] : [[:],[]]
         )
         ch_quast_multiqc = QUAST.out.results
+        QUAST_BYSAMPLE(
+            ch_to_quast_bysample,
+            params.reference_fasta ? [[:], reference_fasta] : [[:],[]],
+            params.reference_gff ? [[:], reference_gff] : [[:],[]]
+        )
     } else if (!params.skip_kmerfinder) {
         // Quast runs twice if kmerfinder is allowed.
         QUAST(
             ch_to_quast,
+            [[:],[]],
+            [[:],[]]
+        )
+        QUAST_BYSAMPLE(
+            ch_to_quast_bysample,
             [[:],[]],
             [[:],[]]
         )

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -90,9 +90,9 @@ workflow BACASS {
     //
     def criteria = multiMapCriteria {
         meta, fastqs, long_fastq, fast5 ->
-            shortreads: fastqs          != 'NA' ? tuple(meta, fastqs) : null
-            longreads:  long_fastq      != 'NA' ? tuple(meta,long_fastq) : null
-            fast5:      fast5           != 'NA' ? tuple(meta, fast5) : null
+            shortreads: fastqs[0]       != 'NA' ? tuple(meta, fastqs)    : tuple(meta, [])
+            longreads:  long_fastq      != 'NA' ? tuple(meta,long_fastq) : tuple(meta, [])
+            fast5:      fast5           != 'NA' ? tuple(meta, fast5)     : tuple(meta, [])
     }
     ch_proteins = params.prokka_proteins ? channel.fromPath(params.prokka_proteins, checkIfExists: true)  : []
     // See the documentation https://nextflow-io.github.io/nf-validation/samplesheets/fromSamplesheet/
@@ -107,21 +107,28 @@ workflow BACASS {
     // reconfigure channels
     ch_input
         .shortreads
-        .filter{ it -> it != null }
+        .filter{ meta, data -> data }
         .set { ch_shortreads }
     ch_input
         .longreads
-        .filter{ it -> it != null }
+        .filter{ meta, data -> data }
         .set { ch_longreads }
     ch_input
         .fast5
-        .filter{ it -> it != null }
+        .filter{ meta, data -> data }
         .set { ch_fast5 }
 
     //
-    // MODULE: Concatenate FastQ files from same sample if required
+    // Short read preprocessing and QC
     //
+    ch_short_preprocessed  = channel.empty()
+    ch_fastqc_raw_multiqc  = channel.empty()
+    ch_fastqc_trim_multiqc = channel.empty()
+    ch_fastp_json_multiqc  = channel.empty()
     if (params.assembly_type in ['short', 'hybrid']) {
+        //
+        // MODULE: Concatenate FastQ files from same sample if required
+        //
         ch_shortreads
             .branch{
                 meta, fastqs ->
@@ -129,19 +136,42 @@ workflow BACASS {
                     multiple: meta.single_end ? fastqs.size() > 1 : fastqs.size() > 2
             }
             .set { ch_shortreads_fastqs }
-
         CAT_FASTQ_SHORT (
             ch_shortreads_fastqs.multiple
         )
-
         ch_shortreads_concat = CAT_FASTQ_SHORT.out.reads
             .mix( ch_shortreads_fastqs.single )
 
-    } else {
-        ch_shortreads_concat = channel.empty()
+        //
+        // SUBWORKFLOW: Short reads QC and trim adapters
+        //
+        FASTQ_TRIM_FASTP_FASTQC (
+            ch_shortreads_concat.map{ meta, reads -> [meta, reads, []] }, //add an empty field for adapters
+            params.save_trimmed_fail,
+            [],
+            params.discard_trimmed_pass,
+            params.skip_fastp,
+            params.skip_fastqc
+        )
+        ch_short_preprocessed   = FASTQ_TRIM_FASTP_FASTQC.out.reads
+        ch_fastqc_raw_multiqc   = FASTQ_TRIM_FASTP_FASTQC.out.fastqc_raw_zip
+        ch_fastqc_trim_multiqc  = FASTQ_TRIM_FASTP_FASTQC.out.fastqc_trim_zip
+        ch_fastp_json_multiqc   = FASTQ_TRIM_FASTP_FASTQC.out.trim_json
+        ch_versions = ch_versions.mix(FASTQ_TRIM_FASTP_FASTQC.out.versions)
     }
 
+    //
+    // Long read preprocessing and QC
+    //
+    ch_pycoqc_multiqc       = channel.empty()
+    ch_nanoplot_txt_multiqc = channel.empty()
+    ch_porechop_log_multiqc = channel.empty()
+    ch_filtlong_log_multiqc = channel.empty()
+    ch_longreads_filtered   = channel.empty()
     if (params.assembly_type in ['long', 'hybrid']) {
+        //
+        // MODULE: Concatenate FastQ files from same sample if required
+        //
         ch_longreads
             .map {
                 meta, long_fastq ->
@@ -156,97 +186,67 @@ workflow BACASS {
                     multiple: long_fastqs.size() > 1
             }
             .set { ch_longreads_fastqs }
-
         CAT_FASTQ_LONG (
             ch_longreads_fastqs.multiple
         )
-
         ch_longreads_concat = CAT_FASTQ_LONG.out.reads
             .mix( ch_longreads_fastqs.single )
 
-    } else {
-        ch_longreads_concat = channel.empty()
-    }
-
-    //
-    // SUBWORKFLOW: Short reads QC and trim adapters
-    //
-    ch_fastqc_raw_multiqc = channel.empty()
-    ch_fastqc_trim_multiqc = channel.empty()
-    ch_fastp_json_multiqc = channel.empty()
-
-    if (params.assembly_type != 'long'){
-        FASTQ_TRIM_FASTP_FASTQC (
-            ch_shortreads_concat.map{ meta, reads -> [meta, reads, []] }, //add an empty field for adapters
-            params.save_trimmed_fail,
-            [],
-            params.discard_trimmed_pass,
-            params.skip_fastp,
-            params.skip_fastqc
+        //
+        // SUBWORKFLOW: quality check for nanopore reads with Nanoplot and ToulligQC
+        //
+        QC_NANOPLOT_TOULLIGQC (
+            ch_longreads_concat,
+            params.skip_nanoplot,  // skip the nanoplot qc
+            params.skip_toulligqc  // skip the toulligqc
         )
-        ch_fastqc_raw_multiqc   = FASTQ_TRIM_FASTP_FASTQC.out.fastqc_raw_zip
-        ch_fastqc_trim_multiqc  = FASTQ_TRIM_FASTP_FASTQC.out.fastqc_trim_zip
-        ch_fastp_json_multiqc   = FASTQ_TRIM_FASTP_FASTQC.out.trim_json
-        ch_versions = ch_versions.mix(FASTQ_TRIM_FASTP_FASTQC.out.versions)
-    }
+        ch_nanoplot_txt_multiqc = QC_NANOPLOT_TOULLIGQC.out.nanoplot_txt
+        ch_versions = ch_versions.mix(QC_NANOPLOT_TOULLIGQC.out.nanoplot_version)
+        ch_versions = ch_versions.mix(QC_NANOPLOT_TOULLIGQC.out.toulligqc_version)
 
-    //
-    // SUBWORKFLOW: quality check for nanopore reads with Nanoplot and ToulligQC
-    //
-    QC_NANOPLOT_TOULLIGQC (
-        ch_longreads_concat,
-        params.skip_nanoplot,  // skip the nanoplot qc
-        params.skip_toulligqc  // skip the toulligqc
-    )
-    ch_nanoplot_txt_multiqc = QC_NANOPLOT_TOULLIGQC.out.nanoplot_txt
-    ch_versions = ch_versions.mix(QC_NANOPLOT_TOULLIGQC.out.nanoplot_version)
-    ch_versions = ch_versions.mix(QC_NANOPLOT_TOULLIGQC.out.toulligqc_version)
-
-
-    //
-    // MODULE: PYCOQC, quality check for nanopore reads and Quality/Length Plots
-    //
-    // TODO: Couldn't be tested. No configuration test available (lack of fast5 file or params.skip_pycoqc=false).
-    ch_pycoqc_multiqc = channel.empty()
-    if ( !params.skip_pycoqc ) {
-        PYCOQC (
-            ch_fast5.dump(tag: 'fast5')
-        )
-        ch_pycoqc_multiqc = PYCOQC.out.json
-        ch_versions       = ch_versions.mix(PYCOQC.out.versions)
-    }
-
-    //
-    // MODULE: PORECHOP, quality check for nanopore reads and Quality/Length Plots
-    //
-    ch_porechop_log_multiqc = channel.empty()
-    if ((params.assembly_type == 'hybrid' || params.assembly_type == 'long' && !('short' in params.assembly_type)) && params.long_reads_filtering == 'porechop' ) {
-        PORECHOP_PORECHOP (
-            ch_longreads_concat.dump(tag: 'longreads')
-        )
-        filtered_long_reads = PORECHOP_PORECHOP.out.reads
-        ch_porechop_log_multiqc = PORECHOP_PORECHOP.out.log
-        ch_versions = ch_versions.mix( PORECHOP_PORECHOP.out.versions )
-    }
-
-    //
-    // MODULE: FILTLONG, filtering long reads by quality. It can take a set of long reads and produce a smaller, better subset.
-    //
-    ch_filtlong_log_multiqc = channel.empty()
-    if ( !('short' in params.assembly_type) && params.long_reads_filtering == 'filtlong' ) {
-        if (params.assembly_type == 'hybrid') {
-            ch_shortreads_for_filtlong = FASTQ_TRIM_FASTP_FASTQC.out.reads.join(ch_longreads_concat)   //tuple val(meta), file(sr), file(lr)
-        } else if ( params.assembly_type == 'long' ) {
-            ch_shortreads_for_filtlong = ch_longreads_concat.map{ meta, lr -> tuple(meta, [], lr ) }
+        //
+        // MODULE: PYCOQC, quality check for nanopore reads and Quality/Length Plots
+        //
+        // TODO: Couldn't be tested. No configuration test available (lack of fast5 file or params.skip_pycoqc=false).
+        if ( !params.skip_pycoqc ) {
+            PYCOQC (
+                ch_fast5.dump(tag: 'fast5')
+            )
+            ch_pycoqc_multiqc = PYCOQC.out.json
+            ch_versions       = ch_versions.mix(PYCOQC.out.versions)
         }
 
-        FILTLONG (
-            ch_shortreads_for_filtlong
-        )
+        //
+        // MODULE: PORECHOP, quality check for nanopore reads and Quality/Length Plots
+        //
+        if ( params.long_reads_filtering == 'porechop' ) {
+            PORECHOP_PORECHOP (
+                ch_longreads_concat.dump(tag: 'longreads')
+            )
+            ch_longreads_filtered   = PORECHOP_PORECHOP.out.reads
+            ch_porechop_log_multiqc = PORECHOP_PORECHOP.out.log
+            ch_versions = ch_versions.mix( PORECHOP_PORECHOP.out.versions )
+        }
 
-        filtered_long_reads = FILTLONG.out.reads
-        ch_filtlong_log_multiqc = FILTLONG.out.log
-        ch_versions       = ch_versions.mix(FILTLONG.out.versions)
+        //
+        // MODULE: FILTLONG, filtering long reads by quality. It can take a set of long reads and produce a smaller, better subset.
+        //
+        if ( params.long_reads_filtering == 'filtlong' ) {
+            ch_shortreads_for_filtlong = channel.empty()
+            if (params.assembly_type == 'hybrid') {
+                ch_shortreads_for_filtlong = ch_short_preprocessed.join(ch_longreads_concat)   //tuple val(meta), file(sr), file(lr)
+            } else if ( params.assembly_type == 'long' ) {
+                ch_shortreads_for_filtlong = ch_longreads_concat.map{ meta, lr -> tuple(meta, [], lr ) }
+            }
+
+            FILTLONG (
+                ch_shortreads_for_filtlong
+            )
+
+            ch_longreads_filtered   = FILTLONG.out.reads
+            ch_filtlong_log_multiqc = FILTLONG.out.log
+            ch_versions       = ch_versions.mix(FILTLONG.out.versions)
+        }
     }
 
 
@@ -255,11 +255,11 @@ workflow BACASS {
     // Prepare channel for Kraken2
     //
     if(params.assembly_type == 'hybrid'){
-        ch_for_kraken2_short    = FASTQ_TRIM_FASTP_FASTQC.out.reads
-        ch_for_kraken2_long     = filtered_long_reads
-        FASTQ_TRIM_FASTP_FASTQC.out.reads
+        ch_for_kraken2_short    = ch_short_preprocessed
+        ch_for_kraken2_long     = ch_longreads_filtered
+        ch_short_preprocessed
             .dump(tag: 'fastp')
-            .cross(filtered_long_reads) { it -> it[0].sample }
+            .cross(ch_longreads_filtered) { it -> it[0].sample }
             .map { short_tuple, long_tuple ->
                 def meta_short = short_tuple[0]
                 def short_reads = short_tuple[1]
@@ -268,22 +268,40 @@ workflow BACASS {
             }
             .dump(tag: 'ch_for_assembly')
             .set { ch_for_assembly }
+        ch_for_assembly.ifEmpty{
+            def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                "  There is nothing to assemble with these settings.\n" +
+                "  Please verify that samples have short and long reads.\n"
+                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+            error(error_string) }
     } else if ( params.assembly_type == 'short' ) {
-        ch_for_kraken2_short    = FASTQ_TRIM_FASTP_FASTQC.out.reads
+        ch_for_kraken2_short    = ch_short_preprocessed
         ch_for_kraken2_long     = channel.empty()
-        FASTQ_TRIM_FASTP_FASTQC.out.reads
+        ch_short_preprocessed
             .dump(tag: 'fastp')
             .map{ meta,reads -> tuple(meta,reads,[]) }
             .dump(tag: 'ch_for_assembly')
             .set { ch_for_assembly }
+        ch_for_assembly.ifEmpty{
+            def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                "  There is nothing to assemble with these settings.\n" +
+                "  Please verify that samples have short reads.\n"
+                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+            error(error_string) }
     } else if ( params.assembly_type == 'long' ) {
         ch_for_kraken2_short    = channel.empty()
-        ch_for_kraken2_long     = filtered_long_reads
-        filtered_long_reads
-            .dump(tag: 'filtered_long_reads')
+        ch_for_kraken2_long     = ch_longreads_filtered
+        ch_longreads_filtered
+            .dump(tag: 'ch_longreads_filtered')
             .map{ meta,lr -> tuple(meta,[],lr) }
             .dump(tag: 'ch_for_assembly')
             .set { ch_for_assembly }
+        ch_for_assembly.ifEmpty{
+            def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                "  There is nothing to assemble with these settings.\n" +
+                "  Please verify that samples have long reads.\n"
+                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+            error(error_string) }
     }
 
     //
@@ -361,7 +379,7 @@ workflow BACASS {
     //
     // MODULE: Miniasm, genome assembly, long reads
     //
-    if ( params.assembly_type != 'short' && ( params.assembler.tokenize(",").contains("miniasm") || ( params.assembler.tokenize(",").contains("autocycler") && params.autocycler_assemblers.tokenize(",").contains("miniasm") ) ) ) {
+    if ( params.assembler.tokenize(",").contains("miniasm") || ( params.assembler.tokenize(",").contains("autocycler") && params.autocycler_assemblers.tokenize(",").contains("miniasm") ) ) {
         ch_for_assembly
             .map{ meta, _short_reads, long_reads ->
                 def new_meta = meta.clone()
@@ -413,8 +431,6 @@ workflow BACASS {
         )
         ch_assembly = ch_assembly.mix( RACON.out.improved_assembly.dump(tag: 'miniasm') )
         ch_versions = ch_versions.mix( RACON.out.versions )
-    } else if (params.assembly_type == 'short' && params.assembler.tokenize(",").contains("miniasm") ) {
-        exit("Selected assembler Miniasm cannot run on short reads")
     }
 
     //
@@ -649,9 +665,9 @@ workflow BACASS {
     if (!params.skip_kmerfinder) {
         // Set kmerfinder channel based on assembly type
         if( params.assembly_type == 'short' || params.assembly_type == 'hybrid' ) {
-            ch_for_kmerfinder = FASTQ_TRIM_FASTP_FASTQC.out.reads
+            ch_for_kmerfinder = ch_short_preprocessed
         } else if ( params.assembly_type == 'long' ) {
-            ch_for_kmerfinder = filtered_long_reads
+            ch_for_kmerfinder = ch_longreads_filtered
         }
         // RUN kmerfinder subworkflow
         KMERFINDER_SUMMARY_DOWNLOAD (


### PR DESCRIPTION
Change to activate all assemblers by default. Addresses Feature 1 of https://github.com/nf-core/bacass/issues/271.

Choosing an incompatible `assembly_type` will emit a warning when data isnt appropriate (albeit after preprocessing, before assembly).

I rearranged the code to first have a block for short read preprocessing, then long read preprocessing. I attempted to unify code before assembly. Empty channels are emitted wherever possible to avoid channel errors.

No change in usage or output expected, except if there were a sample-specific QUAST run (=QUAST_BYSAMPLE, only if: several samples & several assemblers). I seem to not be able to modify an existing test to execute QUAST_BYSAMPLE, because the only three tests that have multiple samples (test, dfast, liftoff) are run on short reads and we have only one short-read assembler in the pipeline (Unicycler), correct?

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
