### PR TITLE
Fix all local strict syntax lint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#284](https://github.com/nf-core/bacass/pull/264) Resolve Nextflow strict syntax warnings
 - [#283](https://github.com/nf-core/bacass/pull/283) Validate `--assembly_type` and `--assembler` compatibility and add dedicated nf-test coverage
 - [#263](https://github.com/nf-core/bacass/pull/263) Update Template to 3.5.1
 - [#264](https://github.com/nf-core/bacass/pull/264) Follow Nextflow strict syntax

--- a/subworkflows/local/kmerfinder_summary_download/main.nf
+++ b/subworkflows/local/kmerfinder_summary_download/main.nf
@@ -74,7 +74,7 @@ workflow KMERFINDER_SUMMARY_DOWNLOAD {
     // Prepare channel for NCBI_DATASETS_DOWNLOAD
     // Extract base accession from winner file (remove assembly version)
     ch_accessions_for_download = KMERFINDER_FIND_WINNER_REFERENCE.out.winner
-        .map { refmeta, winner_file ->
+        .map { _refmeta, winner_file ->
             def full_accession = winner_file.text.trim()
             // Extract base accession: GCF_002795805.1_ASM279580v1 → GCF_002795805.1
             def base_accession = full_accession.split('_')[0] + '_' + full_accession.split('_')[1]
@@ -91,12 +91,12 @@ workflow KMERFINDER_SUMMARY_DOWNLOAD {
     ch_reports_byreference
         .map { species, meta, report_txt, fasta ->
             // Extract base accession from the first report to match with downloads
-            def first_line = report_txt[0].text.split('\n').find { !it.startsWith('#') && it.trim() }
+            def first_line = report_txt[0].text.split('\n').find { line -> !line.startsWith('#') && line.trim() }
             def full_accession = first_line ? first_line.split('\t')[0] : null
             def base_accession = full_accession ? full_accession.split('_')[0] + '_' + full_accession.split('_')[1] : null
             return tuple(base_accession, species, meta, report_txt, fasta)
         }
-        .filter { base_accession, species, meta, report_txt, fasta -> base_accession != null }
+        .filter { base_accession, _species, _meta, _report_txt, _fasta -> base_accession != null }
         .join(
             NCBI_DATASETS_DOWNLOAD.out.fna.map { meta, fna -> tuple(meta.id, fna) },
             by: 0
@@ -106,7 +106,7 @@ workflow KMERFINDER_SUMMARY_DOWNLOAD {
             by: 0
         )
         .map {
-            base_accession, species, meta, report_txt, fasta, fna, gff ->
+            base_accession, _species, meta, _report_txt, fasta, fna, gff ->
                 return tuple([id: base_accession], meta, fasta, fna, gff)
         }
         .set { ch_consensus_byrefseq }

--- a/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
@@ -235,7 +235,7 @@ def validateInputParameters() {
     }
 
     // Check compatibility between assembly_type and selected assembler(s)
-    def selected_assemblers = params.assembler.tokenize(",").collect { it.trim() }.findAll { it }
+    def selected_assemblers = params.assembler.tokenize(",").collect { v -> v.trim() }.findAll { v -> v }
     Map<String, Map<String, Boolean>> assembler_capabilities = [
         unicycler : [short: true,  long: true,  hybrid: true ],
         megahit   : [short: true,  long: false, hybrid: false],

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -109,15 +109,15 @@ workflow BACASS {
     // reconfigure channels
     ch_input
         .shortreads
-        .filter{ meta, data -> data }
+        .filter{ _meta, data -> data }
         .set { ch_shortreads }
     ch_input
         .longreads
-        .filter{ meta, data -> data }
+        .filter{ _meta, data -> data }
         .set { ch_longreads }
     ch_input
         .fast5
-        .filter{ meta, data -> data }
+        .filter{ _meta, data -> data }
         .set { ch_fast5 }
 
     //
@@ -337,7 +337,7 @@ workflow BACASS {
     //
     if ( params.assembler.tokenize(",").contains("unicycler") ) {
         ch_for_assembly
-            .filter{ meta, sr, lr -> !meta.subsample } // subsamples are not entering. i.e. anything with "meta.subsample"
+            .filter{ meta, _sr, _lr -> !meta.subsample } // subsamples are not entering. i.e. anything with "meta.subsample"
             .map{ meta, sr, lr ->
                 def new_meta = meta.clone()
                 new_meta.assembler = "unicycler"
@@ -386,7 +386,7 @@ workflow BACASS {
                 new_meta.id = meta.subsample ? "${meta.id}-${meta.subsample}-canu" : meta.id + "-canu"
                 [ new_meta, long_reads ]
             }
-            .filter { meta, lr ->
+            .filter { meta, _lr ->
                 params.assembler.tokenize(",").contains("autocycler") && !params.assembler.tokenize(",").contains("canu") ? meta.subsample : // if with autocycler and not canu accept only subsamples
                     !params.assembler.tokenize(",").contains("autocycler") && params.assembler.tokenize(",").contains("canu") ? !meta.subsample : true // if without autocycler and with canu reject subsample
             }
@@ -411,7 +411,7 @@ workflow BACASS {
                 new_meta.id = meta.subsample ? "${meta.id}-${meta.subsample}-miniasm" : meta.id + "-miniasm"
                 [ new_meta, long_reads ]
             }
-            .filter { meta, lr ->
+            .filter { meta, _lr ->
                 params.assembler.tokenize(",").contains("autocycler") && params.autocycler_assemblers.tokenize(",").contains("miniasm") && params.assembler.tokenize(",").contains("miniasm") ? true : // if with autocycler and miniasm accept all data sets
                     params.assembler.tokenize(",").contains("autocycler") && params.autocycler_assemblers.tokenize(",").contains("miniasm") && !params.assembler.tokenize(",").contains("miniasm") ? meta.subsample : // if with autocycler and not miniasm accept only subsamples
                     ( !params.assembler.tokenize(",").contains("autocycler") || !params.autocycler_assemblers.tokenize(",").contains("miniasm") ) && params.assembler.tokenize(",").contains("miniasm") ? !meta.subsample : false // if without autocycler and with miniasm reject subsample
@@ -468,7 +468,7 @@ workflow BACASS {
                 new_meta.id = meta.id + "-dragonflye"
                 [ new_meta, short_reads, long_reads ]
             }
-            .filter{ meta, sr, lr -> !meta.subsample } // subsamples are not entering. i.e. anything with "meta.subsample"
+            .filter{ meta, _sr, _lr -> !meta.subsample } // subsamples are not entering. i.e. anything with "meta.subsample"
             .set { ch_for_assembly_dragonflye }
 
         DRAGONFLYE(
@@ -489,7 +489,7 @@ workflow BACASS {
                 new_meta.id = meta.subsample ? "${meta.id}-${meta.subsample}-raven" : meta.id + "-raven"
                 [ new_meta, long_reads ]
             }
-            .filter { meta, lr ->
+            .filter { meta, _lr ->
                 params.assembler.tokenize(",").contains("autocycler") && !params.assembler.tokenize(",").contains("raven") ? meta.subsample : // if with autocycler and not raven accept only subsamples
                     !params.assembler.tokenize(",").contains("autocycler") && params.assembler.tokenize(",").contains("raven") ? !meta.subsample : true // if without autocycler and with raven reject subsample
             }
@@ -512,7 +512,7 @@ workflow BACASS {
                 new_meta.id = meta.subsample ? "${meta.id}-${meta.subsample}-flye" : meta.id + "-flye"
                 [ new_meta, long_reads ]
             }
-            .filter { meta, lr ->
+            .filter { meta, _lr ->
                 params.assembler.tokenize(",").contains("autocycler") && !params.assembler.tokenize(",").contains("flye") ? meta.subsample : // if with autocycler and not flye accept only subsamples
                     !params.assembler.tokenize(",").contains("autocycler") && params.assembler.tokenize(",").contains("flye") ? !meta.subsample : true // if without autocycler and with flye reject subsample
             }
@@ -529,7 +529,7 @@ workflow BACASS {
     //
     if( params.assembler.tokenize(",").contains("autocycler") ){
         ch_assembly
-            .filter{ meta, assembly -> meta.subsample } // only assemblies of subsamples pass, i.e. anything with "meta.subsample"
+            .filter{ meta, _assembly -> meta.subsample } // only assemblies of subsamples pass, i.e. anything with "meta.subsample"
             .map{ meta, assembly ->
                 def new_meta = meta.clone()
                 new_meta.remove("subsample")
@@ -537,7 +537,7 @@ workflow BACASS {
                 new_meta.id = meta.sample + "-autocycler"
                 [ new_meta, assembly ]
             }
-            .filter{ meta, assembly -> assembly.countLines() > 1 } // keep only non-empty assembly files
+            .filter{ _meta, assembly -> assembly.countLines() > 1 } // keep only non-empty assembly files
             .groupTuple() // group to "[ val(meta), [ fasta, fasta, ... ] ]"
             .set { ch_assembly_autocycler }
 
@@ -552,7 +552,7 @@ workflow BACASS {
 
     // clean assemblies from subsamples
     ch_assembly
-        .filter { meta, assembly -> !meta.subsample } // omit subsample assemblies
+        .filter { meta, _assembly -> !meta.subsample } // omit subsample assemblies
         .set { ch_assembly }
 
     //
@@ -561,7 +561,7 @@ workflow BACASS {
     if ( (params.assembly_type == 'long' && !params.skip_polish) || ( params.assembly_type != 'short' && params.polish_method) ){
         // Set channel for polishing long reads
         ch_for_assembly
-            .filter { meta, sr, lr -> !meta.subsample } // remove any subsamples
+            .filter { meta, _sr, _lr -> !meta.subsample } // remove any subsamples
             .cross(ch_assembly) { it -> it[0].sample } // merge by meta.sample -> [[ meta, sr, lr ],[ meta, assembly ]]
             .map { for_assembly,assembly ->
                 def meta_assembly  = assembly[0]
@@ -731,11 +731,11 @@ workflow BACASS {
     ch_assembly
         .map { meta, file -> [meta.sample, meta, file] }
         .combine(ch_multisamples)                                                          // When ch_multisamples is empty, nothing will be forwarded
-        .filter { sample_name, meta, files, valid_sample -> sample_name == valid_sample }  // The previous step produced too many combinations, reduce to genuine entries
-        .map { sample_name, metas, files, valid_sample -> [sample_name, metas, files] }
+        .filter { sample_name, _meta, _files, valid_sample -> sample_name == valid_sample }  // The previous step produced too many combinations, reduce to genuine entries
+        .map { sample_name, metas, files, _valid_sample -> [sample_name, metas, files] }
         .groupTuple(by: 0) // Group by samples
         .map { sample_name, _meta, files -> [ [id: sample_name], files ] } // Drop meta information
-        .filter { meta, files -> files.size() > 1 } // Only keep samples that have several assemblies
+        .filter { _meta, files -> files.size() > 1 } // Only keep samples that have several assemblies
         .set { ch_to_quast_bysample }
 
     if(params.skip_kmerfinder){


### PR DESCRIPTION
  ## Summary                                                
  Nextflow strict syntax compliance is becoming mandatory for nf-core pipelines. This PR resolves all 34 lint warnings in local files, covering unused 
  closure parameters and implicit `it` usage.

Previous PR [https://github.com/nf-core/bacass/pull/264](264) fixed all errors and warnings. The warnings fixed here were introduced after that PR.

  - Prefix unused closure parameters with `_` in `workflows/bacass.nf` (21 warnings)
  - Prefix unused params and replace implicit `it` in `subworkflows/local/kmerfinder_summary_download/main.nf` (10 warnings)
  - Replace implicit `it` with explicit closure parameters in `subworkflows/local/utils_nfcore_bacass_pipeline/main.nf` (2 warnings)

  The remaining 15 warnings are in `modules/nf-core/*` and `subworkflows/nf-core/*` and should be addressed via `nf-core modules update`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
