### PR TITLE
Add assembly_type=auto detection and heterogeneous assembler

### DIFF
--- a/modules/local/custom/multiqc/main.nf
+++ b/modules/local/custom/multiqc/main.nf
@@ -52,7 +52,7 @@ process CUSTOM_MULTIQC {
 
     ## Avoid the custom Multiqc table when the kmerfinder process is not invoked.
     if grep ">skip_kmerfinder<" workflow_summary_mqc.yaml; then
-        rm *_assembly_metrics_mqc.csv
+        rm -f *_assembly_metrics_mqc.csv
     fi
 
     ## Run multiqc a second time

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,7 +28,7 @@ params {
 
     // Assembly parameters
     assembler                       = 'autocycler,canu,dragonflye,flye,megahit,miniasm,unicycler,raven'  // Allowed: comma separated list of available assembler
-    assembly_type                   = null       // Allowed: ['short', 'long', 'hybrid'] (hybrid works only with Unicycler)
+    assembly_type                   = 'auto'     // Allowed: ['auto', 'short', 'long', 'hybrid'] ('auto' to autodetect from samplesheet; hybrid works only with Unicycler)
     unicycler_args                  = ""
     canu_mode                       = '-nanopore'   // Allowed: ['-pacbio', '-nanopore', '-pacbio-hifi']
     canu_args                       = ''            // Default no extra options, can be adjusted by the user

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -19,7 +19,7 @@
                     "schema": "assets/schema_input.json",
                     "mimetype": "text/csv",
                     "description": "Path to tab-separated sample sheet",
-                    "help_text": "Path to sample sheet, either tab-separated (.tsv), comma-separated (.csv), or in YAML format (.yml/.yaml), that points to compressed fastq files.\n\nThe sample sheet must have six tab-separated columns/entries with the following headers: \n- `ID` (required): Unique sample IDs, must start with a letter, and can only contain letters, numbers or underscores\n- `R1` (optional): Paths to (forward) reads zipped FastQ files\n- `R2` (optional): Paths to reverse reads zipped FastQ files, required if the data is paired-end\n- `LongFastQ` (optional): Paths to long reads zipped FastQ files\n- `Fast5` (optional): Paths to the directory containing FAST5 files\n- `GenomeSize` (optional): A number (including decimals) ending with 'm', representing genome size.\n\n Please be aware that files will be required based on the chosen assembly type specified with the '--assembly_type' option, which can be set to one of the following values: ['short', 'long', 'hybrid'].`",
+                    "help_text": "Path to sample sheet, either tab-separated (.tsv), comma-separated (.csv), or in YAML format (.yml/.yaml), that points to compressed fastq files.\n\nThe sample sheet must have six tab-separated columns/entries with the following headers: \n- `ID` (required): Unique sample IDs, must start with a letter, and can only contain letters, numbers or underscores\n- `R1` (optional): Paths to (forward) reads zipped FastQ files\n- `R2` (optional): Paths to reverse reads zipped FastQ files, required if the data is paired-end\n- `LongFastQ` (optional): Paths to long reads zipped FastQ files\n- `Fast5` (optional): Paths to the directory containing FAST5 files\n- `GenomeSize` (optional): A number (including decimals) ending with 'm', representing genome size.\n\n Please be aware that files will be required based on the chosen assembly type specified with the '--assembly_type' option, which can be set to one of the following values: ['auto', 'short', 'long', 'hybrid'].`",
                     "fa_icon": "fas fa-dna"
                 },
                 "outdir": {
@@ -137,10 +137,11 @@
                 },
                 "assembly_type": {
                     "type": "string",
+                    "default": "auto",
                     "fa_icon": "fas fa-fingerprint",
-                    "help_text": "This adjusts the type of assembly done with the input data and can be any of `long`, `short` or `hybrid`.",
+                    "help_text": "This adjusts the type of assembly done with the input data and can be any of `auto`, `long`, `short` or `hybrid`. With `auto`, the assembly type is inferred from the samplesheet.",
                     "description": "Which type of assembly to perform.",
-                    "enum": ["short", "long", "hybrid"]
+                    "enum": ["auto", "short", "long", "hybrid"]
                 },
                 "unicycler_args": {
                     "type": "string",

--- a/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
@@ -93,16 +93,36 @@ workflow PIPELINE_INITIALISATION {
     )
 
     //
+    // Parse samplesheet once so it can be reused for autodetection and channel creation
+    //
+    def parsed_samplesheet = samplesheetToList(input, "${projectDir}/assets/schema_input.json")
+
+    //
+    // Resolve assembly_type automatically from samplesheet if requested
+    //
+    def auto_detected_sample_types = []
+    if (params.assembly_type == 'auto') {
+        def inferred_sample_types = inferAssemblyTypesFromSamplesheet(parsed_samplesheet)
+        def inferred_global_types = inferred_sample_types.values().toSet()
+        auto_detected_sample_types = inferred_global_types.toList().sort()
+
+        if (inferred_global_types.size() == 1) {
+            log.info "Auto-detected '--assembly_type' as '${auto_detected_sample_types.first()}' from samplesheet."
+        } else {
+            log.info "Auto-detected heterogeneous per-sample assembly types: ${auto_detected_sample_types.join(', ')}"
+        }
+    }
+
+    //
     // Custom validation for pipeline parameters
     //
-    validateInputParameters()
+    validateInputParameters(auto_detected_sample_types)
 
     //
     // Create channel from input file provided through params.input
     //
-
     channel
-        .fromList(samplesheetToList(input, "${projectDir}/assets/schema_input.json"))
+        .fromList(parsed_samplesheet)
         .map {
             meta, fastq_1, fastq_2, longreads, fast5 ->
 
@@ -124,7 +144,9 @@ workflow PIPELINE_INITIALISATION {
         }
         .map {
             meta, fastqs, longread, fast5 ->
-                return [ meta, fastqs.flatten(), longread, fast5[0] ]
+                def merged_longread = longread.flatten().find { hasInputValue(it) } ?: 'NA'
+                def merged_fast5 = fast5.flatten().find { hasInputValue(it) } ?: 'NA'
+                return [ meta, fastqs.flatten(), merged_longread, merged_fast5 ]
         }
         .set { ch_samplesheet }
 
@@ -189,7 +211,7 @@ workflow PIPELINE_COMPLETION {
 //
 // Check and validate pipeline parameters
 //
-def validateInputParameters() {
+def validateInputParameters(auto_detected_sample_types = []) {
     // Add functions here for parameters validation
     // Check Kraken2 dependencies
     if (!params.skip_kraken2 && !params.kraken2db) {
@@ -246,6 +268,7 @@ def validateInputParameters() {
         raven     : [short: false, long: true,  hybrid: false],
         autocycler: [short: false, long: true,  hybrid: false]
     ]
+<<<<<<< HEAD
     def incompatible_assemblers = selected_assemblers.findAll { assembler ->
         !assembler_capabilities.containsKey(assembler) || !assembler_capabilities[assembler][params.assembly_type]
     }
@@ -261,6 +284,48 @@ def validateInputParameters() {
             "  compatible for ${params.assembly_type}: ${compatible_for_type.join(", ")}\n" +
             "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         error(error_string)
+=======
+    if (params.assembly_type == 'auto') {
+        def detected_types = auto_detected_sample_types.collect { it.toString().trim() }.findAll { it }
+        def uncovered_detected_types = detected_types.findAll { detected_type ->
+            !selected_assemblers.any { assembler ->
+                assembler_capabilities.containsKey(assembler) && assembler_capabilities[assembler][detected_type]
+            }
+        }
+        def invalid_assemblers = selected_assemblers.findAll { assembler ->
+            !assembler_capabilities.containsKey(assembler)
+        }
+        if (invalid_assemblers || uncovered_detected_types) {
+            def incompatible_assemblers = selected_assemblers.findAll { assembler ->
+                !assembler_capabilities.containsKey(assembler) ||
+                    uncovered_detected_types.any { detected_type -> !assembler_capabilities[assembler][detected_type] }
+            }
+            def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                "  Incompatible assembler(s) for '--assembly_type auto'.\n" +
+                "  detected per-sample types: ${detected_types.join(", ")}\n" +
+                "  selected: ${selected_assemblers.join(", ")}\n" +
+                "  incompatible: ${incompatible_assemblers.join(", ")}\n" +
+                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+            error(error_string)
+        }
+    } else {
+        def incompatible_assemblers = selected_assemblers.findAll { assembler ->
+            !assembler_capabilities.containsKey(assembler) || !assembler_capabilities[assembler][params.assembly_type]
+        }
+        if (incompatible_assemblers) {
+            def compatible_for_type = compatible_assemblers.findAll { assembler ->
+                assembler_capabilities[assembler]?.get(params.assembly_type) == true
+            }
+            def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                "  Incompatible assembler(s) for the selected assembly type.\n" +
+                "  assembly_type: ${params.assembly_type}\n" +
+                "  selected: ${selected_assemblers.join(", ")}\n" +
+                "  incompatible: ${incompatible_assemblers.join(", ")}\n" +
+                "  compatible for ${params.assembly_type}: ${compatible_for_type.join(", ")}\n" +
+                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+            error(error_string)
+        }
+>>>>>>> cf0172e (Add auto assembly type detection)
     }
 
     // Check that assemblers for Autocycler are chosen correctly
@@ -279,6 +344,38 @@ def validateInputParameters() {
     }
 }
 
+def hasInputValue(value) {
+    value != null && value.toString().trim() && value.toString().trim().toUpperCase() != 'NA'
+}
+
+def inferSampleAssemblyType(boolean has_short_reads, boolean has_long_reads, String sample_id) {
+    if (has_short_reads && has_long_reads) return 'hybrid'
+    if (has_short_reads) return 'short'
+    if (has_long_reads) return 'long'
+
+    def sample_label = sample_id ?: '<unknown>'
+    def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+        "  Invalid sample '${sample_label}': neither short nor long reads were provided.\n" +
+        "  Please provide R1/R2 and/or LongFastQ in the samplesheet.\n" +
+        "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    error(error_string)
+}
+
+def inferAssemblyTypesFromSamplesheet(samplesheet_rows) {
+    def sample_presence = [:].withDefault { [short: false, long: false] }
+
+    samplesheet_rows.each { row ->
+        def (meta, fastq_1, _fastq_2, longreads, _fast5) = row
+        def sample_id = meta.sample
+        sample_presence[sample_id].short = sample_presence[sample_id].short || hasInputValue(fastq_1)
+        sample_presence[sample_id].long = sample_presence[sample_id].long || hasInputValue(longreads)
+    }
+
+    sample_presence.collectEntries { sample_id, presence ->
+        [sample_id, inferSampleAssemblyType(presence.short, presence.long, sample_id)]
+    }
+}
+
 //
 // Validate channels from input samplesheet
 //
@@ -290,7 +387,13 @@ def validateInputSamplesheet(input) {
         error("Please check input samplesheet -> Multiple runs of a sample must be of the same datatype i.e. single-end or paired-end: ${metas[0].sample}")
     }
 
-    return [ metas[0], fastqs, longread, fast5]
+    def sample_id = metas[0].sample
+    def has_short_reads = fastqs.flatten().any { hasInputValue(it) }
+    def has_long_reads = longread.flatten().any { hasInputValue(it) }
+    def sample_assembly_type = inferSampleAssemblyType(has_short_reads, has_long_reads, sample_id)
+    def updated_meta = metas[0] + [assembly_type: sample_assembly_type]
+
+    return [ updated_meta, fastqs, longread, fast5]
 }
 
 //

--- a/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
@@ -144,9 +144,7 @@ workflow PIPELINE_INITIALISATION {
         }
         .map {
             meta, fastqs, longread, fast5 ->
-                def merged_longread = longread.flatten().find { hasInputValue(it) } ?: 'NA'
-                def merged_fast5 = fast5.flatten().find { hasInputValue(it) } ?: 'NA'
-                return [ meta, fastqs.flatten(), merged_longread, merged_fast5 ]
+                return [ meta, fastqs.flatten(), longread, fast5[0] ]
         }
         .set { ch_samplesheet }
 

--- a/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_bacass_pipeline/main.nf
@@ -268,23 +268,6 @@ def validateInputParameters(auto_detected_sample_types = []) {
         raven     : [short: false, long: true,  hybrid: false],
         autocycler: [short: false, long: true,  hybrid: false]
     ]
-<<<<<<< HEAD
-    def incompatible_assemblers = selected_assemblers.findAll { assembler ->
-        !assembler_capabilities.containsKey(assembler) || !assembler_capabilities[assembler][params.assembly_type]
-    }
-    if (incompatible_assemblers) {
-        def compatible_for_type = compatible_assemblers.findAll { assembler ->
-            assembler_capabilities[assembler]?.get(params.assembly_type) == true
-        }
-        def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-            "  Incompatible assembler(s) for the selected assembly type.\n" +
-            "  assembly_type: ${params.assembly_type}\n" +
-            "  selected: ${selected_assemblers.join(", ")}\n" +
-            "  incompatible: ${incompatible_assemblers.join(", ")}\n" +
-            "  compatible for ${params.assembly_type}: ${compatible_for_type.join(", ")}\n" +
-            "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        error(error_string)
-=======
     if (params.assembly_type == 'auto') {
         def detected_types = auto_detected_sample_types.collect { it.toString().trim() }.findAll { it }
         def uncovered_detected_types = detected_types.findAll { detected_type ->
@@ -325,7 +308,6 @@ def validateInputParameters(auto_detected_sample_types = []) {
                 "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
             error(error_string)
         }
->>>>>>> cf0172e (Add auto assembly type detection)
     }
 
     // Check that assemblers for Autocycler are chosen correctly

--- a/tests/assembly_type_assembler_compat.nf.test
+++ b/tests/assembly_type_assembler_compat.nf.test
@@ -51,21 +51,46 @@ nextflow_pipeline {
         }
     }
 
-    test("passes when assembly_type=short and assembler=unicycler") {
+    test("fails when assembly_type=auto with heterogeneous samplesheet and assembler=flye") {
 
         when {
             params {
                 outdir = "$outputDir"
-                input = "https://raw.githubusercontent.com/nf-core/test-datasets/bacass/bacass_short_reseq.tsv"
-                assembly_type = "short"
-                assembler = "unicycler"
+                input = "https://raw.githubusercontent.com/nf-core/test-datasets/bacass/bacass_auto_heterogeneous.tsv"
+                assembly_type = "auto"
+                assembler = "flye"
+                skip_kraken2 = true
+                skip_kmerfinder = true
+            }
+        }
+
+        then {
+            def logs = "${workflow.stdout ?: ''}${workflow.stderr ?: ''}"
+            assertAll(
+                { assert !workflow.success },
+                { assert logs.contains("Incompatible assembler(s) for '--assembly_type auto'.") },
+                { assert logs.contains("detected per-sample types: hybrid, long, short") },
+                { assert logs.contains("incompatible: flye") }
+            )
+        }
+    }
+
+    test("passes when assembly_type=auto with long-only samplesheet (stub)") {
+
+        options "-stub"
+
+        when {
+            params {
+                outdir = "$outputDir"
+                input = "https://raw.githubusercontent.com/nf-core/test-datasets/bacass/bacass_long_miniasm.tsv"
+                assembly_type = "auto"
+                assembler = "flye"
                 skip_kraken2 = true
                 skip_kmerfinder = true
                 skip_annotation = true
                 skip_busco = true
+                skip_polish = true
                 skip_multiqc = true
-                skip_fastqc = true
-                skip_fastp = true
             }
         }
 
@@ -78,4 +103,5 @@ nextflow_pipeline {
             )
         }
     }
+
 }

--- a/tests/assembly_type_assembler_compat.nf.test.snap
+++ b/tests/assembly_type_assembler_compat.nf.test.snap
@@ -1,22 +1,31 @@
 {
-    "passes when assembly_type=short and assembler=unicycler": {
+    "passes when assembly_type=auto with long-only samplesheet (stub)": {
         "content": [
             {
-                "CAT_FASTQ_SHORT": {
+                "CAT_FASTQ_LONG": {
                     "cat": 9.5
+                },
+                "FLYE": {
+                    "flye": "2.9.5-b1801"
+                },
+                "NANOPLOT": {
+                    "nanoplot": "1.46.1"
+                },
+                "PORECHOP_PORECHOP": {
+                    "porechop": "0.2.4"
                 },
                 "QUAST": {
                     "quast": "5.3.0"
                 },
-                "UNICYCLER": {
-                    "unicycler": "0.5.1"
+                "TOULLIGQC": {
+                    "toulligqc": "2.7.1"
                 },
                 "Workflow": {
                     "nf-core/bacass": "v2.6.0dev"
                 }
             }
         ],
-        "timestamp": "2026-03-12T09:46:41.11884653",
+        "timestamp": "2026-03-13T11:01:56.986610047",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -127,7 +127,7 @@ workflow BACASS {
     ch_fastqc_raw_multiqc  = channel.empty()
     ch_fastqc_trim_multiqc = channel.empty()
     ch_fastp_json_multiqc  = channel.empty()
-    if (params.assembly_type in ['short', 'hybrid']) {
+    if (params.assembly_type in ['short', 'hybrid', 'auto']) {
         //
         // MODULE: Concatenate FastQ files from same sample if required
         //
@@ -170,7 +170,7 @@ workflow BACASS {
     ch_porechop_log_multiqc = channel.empty()
     ch_filtlong_log_multiqc = channel.empty()
     ch_longreads_filtered   = channel.empty()
-    if (params.assembly_type in ['long', 'hybrid']) {
+    if (params.assembly_type in ['long', 'hybrid', 'auto']) {
         //
         // MODULE: Concatenate FastQ files from same sample if required
         //
@@ -239,6 +239,23 @@ workflow BACASS {
                 ch_shortreads_for_filtlong = ch_short_preprocessed.join(ch_longreads_concat)   //tuple val(meta), file(sr), file(lr)
             } else if ( params.assembly_type == 'long' ) {
                 ch_shortreads_for_filtlong = ch_longreads_concat.map{ meta, lr -> tuple(meta, [], lr ) }
+            } else if ( params.assembly_type == 'auto' ) {
+                ch_shortreads_for_filtlong = ch_short_preprocessed
+                    .filter { meta, _sr -> meta.assembly_type == 'hybrid' }
+                    .cross(
+                        ch_longreads_concat.filter { meta, _lr -> meta.assembly_type == 'hybrid' }
+                    ) { it -> it[0].sample }
+                    .map { short_tuple, long_tuple ->
+                        def meta_short = short_tuple[0]
+                        def short_reads = short_tuple[1]
+                        def long_reads = long_tuple[1]
+                        [meta_short, short_reads, long_reads]
+                    }
+                    .mix(
+                        ch_longreads_concat
+                            .filter { meta, _lr -> meta.assembly_type == 'long' }
+                            .map { meta, lr -> tuple(meta, [], lr) }
+                    )
             }
 
             FILTLONG (
@@ -304,6 +321,42 @@ workflow BACASS {
                 "  Please verify that samples have long reads.\n"
                 "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
             error(error_string) }
+    } else if ( params.assembly_type == 'auto' ) {
+        ch_for_kraken2_short = ch_short_preprocessed
+        ch_for_kraken2_long  = ch_longreads_filtered
+
+        def ch_short_for_assembly = ch_short_preprocessed
+            .filter { meta, _sr -> meta.assembly_type == 'short' }
+            .map { meta, reads -> tuple(meta, reads, []) }
+
+        def ch_long_for_assembly = ch_longreads_filtered
+            .filter { meta, _lr -> meta.assembly_type == 'long' }
+            .map { meta, lr -> tuple(meta, [], lr) }
+
+        def ch_hybrid_for_assembly = ch_short_preprocessed
+            .filter { meta, _sr -> meta.assembly_type == 'hybrid' }
+            .cross(
+                ch_longreads_filtered.filter { meta, _lr -> meta.assembly_type == 'hybrid' }
+            ) { it -> it[0].sample }
+            .map { short_tuple, long_tuple ->
+                def meta_short = short_tuple[0]
+                def short_reads = short_tuple[1]
+                def long_reads = long_tuple[1]
+                [meta_short, short_reads, long_reads]
+            }
+
+        ch_short_for_assembly
+            .mix(ch_long_for_assembly)
+            .mix(ch_hybrid_for_assembly)
+            .dump(tag: 'ch_for_assembly')
+            .set { ch_for_assembly }
+
+        ch_for_assembly.ifEmpty{
+            def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                "  There is nothing to assemble with these settings.\n" +
+                "  Please verify that samples have short and/or long reads.\n"
+                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+            error(error_string) }
     }
 
     //
@@ -312,8 +365,10 @@ workflow BACASS {
     if( params.assembler.tokenize(",").contains("autocycler") ) {
         // subsample and transpose to one subset per channel entry
         AUTOCYCLER_SUBSAMPLE (
-            ch_for_assembly.map{ meta, _short_reads, long_reads -> [meta, long_reads] },
-            ch_for_assembly.map { meta, _reads, _lr -> meta.gsize }
+            filterByCompatibleAssemblyTypes(ch_for_assembly, 'autocycler')
+                .map{ meta, _short_reads, long_reads -> [meta, long_reads] },
+            filterByCompatibleAssemblyTypes(ch_for_assembly, 'autocycler')
+                .map { meta, _reads, _lr -> meta.gsize }
         )
         AUTOCYCLER_SUBSAMPLE.out.subsampled_reads // transpose to [ meta, fasta-subset1, fasta-subset2, ... ]
             .transpose() // transpose to [ meta, fasta ]
@@ -331,12 +386,24 @@ workflow BACASS {
     // ASSEMBLY: Unicycler, Megahit, Canu, Miniasm, Dragonflye, Raven, Flye, Autocycler
     //
     ch_assembly = channel.empty()
+    def assembler_sample_type_compatibility = [
+        unicycler : ['short', 'long', 'hybrid'] as Set,
+        canu      : ['long'] as Set,
+        miniasm   : ['long'] as Set,
+        dragonflye: ['long', 'hybrid'] as Set,
+        raven     : ['long'] as Set,
+        flye      : ['long'] as Set,
+        autocycler: ['long'] as Set
+    ]
+    def filterByCompatibleAssemblyTypes = { channel_input, assembler_name ->
+        channel_input.filter { meta, _sr, _lr -> assembler_sample_type_compatibility[assembler_name].contains(meta.assembly_type) }
+    }
 
     //
     // MODULE: Unicycler, genome assembly, nf-core module allows only short, long and hybrid assembly
     //
     if ( params.assembler.tokenize(",").contains("unicycler") ) {
-        ch_for_assembly
+        filterByCompatibleAssemblyTypes(ch_for_assembly, 'unicycler')
             .filter{ meta, sr, lr -> !meta.subsample } // subsamples are not entering. i.e. anything with "meta.subsample"
             .map{ meta, sr, lr ->
                 def new_meta = meta.clone()
@@ -379,7 +446,7 @@ workflow BACASS {
     // MODULE: Canu, genome assembly, long reads
     //
     if ( params.assembler.tokenize(",").contains("canu") || ( params.assembler.tokenize(",").contains("autocycler") && params.autocycler_assemblers.tokenize(",").contains("canu") ) ) {
-        ch_for_assembly
+        filterByCompatibleAssemblyTypes(ch_for_assembly, 'canu')
             .map{ meta, _short_reads, long_reads ->
                 def new_meta = meta.clone()
                 new_meta.assembler = "canu"
@@ -404,7 +471,7 @@ workflow BACASS {
     // MODULE: Miniasm, genome assembly, long reads
     //
     if ( params.assembler.tokenize(",").contains("miniasm") || ( params.assembler.tokenize(",").contains("autocycler") && params.autocycler_assemblers.tokenize(",").contains("miniasm") ) ) {
-        ch_for_assembly
+        filterByCompatibleAssemblyTypes(ch_for_assembly, 'miniasm')
             .map{ meta, _short_reads, long_reads ->
                 def new_meta = meta.clone()
                 new_meta.assembler = "miniasm"
@@ -461,7 +528,7 @@ workflow BACASS {
     // MODULE: Dragonflye, genome assembly of long reads. Moreover, it provides the option for polishing the draft genome using short reads when both short and long reads are available.
     //
     if( params.assembler.tokenize(",").contains("dragonflye") ){
-        ch_for_assembly
+        filterByCompatibleAssemblyTypes(ch_for_assembly, 'dragonflye')
             .map{ meta, short_reads, long_reads ->
                 def new_meta = meta.clone()
                 new_meta.assembler = "dragonflye"
@@ -482,7 +549,7 @@ workflow BACASS {
     // MODULE: Raven, genome assembly of long reads.
     //
     if ( params.assembler.tokenize(",").contains("raven") || ( params.assembler.tokenize(",").contains("autocycler") && params.autocycler_assemblers.tokenize(",").contains("raven") ) ) {
-        ch_for_assembly
+        filterByCompatibleAssemblyTypes(ch_for_assembly, 'raven')
             .map{ meta, _short_reads, long_reads ->
                 def new_meta = meta.clone()
                 new_meta.assembler = "raven"
@@ -505,7 +572,7 @@ workflow BACASS {
     // MODULE: Flye, genome assembly of long reads.
     //
     if ( params.assembler.tokenize(",").contains("flye") || ( params.assembler.tokenize(",").contains("autocycler") && params.autocycler_assemblers.tokenize(",").contains("flye") ) ) {
-        ch_for_assembly
+        filterByCompatibleAssemblyTypes(ch_for_assembly, 'flye')
             .map{ meta, _short_reads, long_reads ->
                 def new_meta = meta.clone()
                 new_meta.assembler = "flye"
@@ -558,9 +625,10 @@ workflow BACASS {
     //
     // SUBWORKFLOW: Long reads polishing. Uses medaka or Nanopolish (this last requires Fast5 files available in input samplesheet).
     //
-    if ( (params.assembly_type == 'long' && !params.skip_polish) || ( params.assembly_type != 'short' && params.polish_method) ){
+    if ( !params.skip_polish && params.polish_method && params.assembly_type != 'short' ){
         // Set channel for polishing long reads
         ch_for_assembly
+            .filter { meta, _sr, _lr -> meta.assembly_type in ['long', 'hybrid'] }
             .filter { meta, sr, lr -> !meta.subsample } // remove any subsamples
             .cross(ch_assembly) { it -> it[0].sample } // merge by meta.sample -> [[ meta, sr, lr ],[ meta, assembly ]]
             .map { for_assembly,assembly ->
@@ -692,6 +760,13 @@ workflow BACASS {
             ch_for_kmerfinder = ch_short_preprocessed
         } else if ( params.assembly_type == 'long' ) {
             ch_for_kmerfinder = ch_longreads_filtered
+        } else if ( params.assembly_type == 'auto' ) {
+            ch_for_kmerfinder = ch_short_preprocessed
+                .filter { meta, _reads -> meta.assembly_type in ['short', 'hybrid'] }
+                .mix(
+                    ch_longreads_filtered
+                        .filter { meta, _reads -> meta.assembly_type == 'long' }
+                )
         }
         // RUN kmerfinder subworkflow
         KMERFINDER_SUMMARY_DOWNLOAD (
@@ -907,38 +982,42 @@ workflow BACASS {
     //
     // MODULE: MultiQC
     //
-    ch_multiqc_config                     = !params.skip_kmerfinder && params.assembly_type ? channel.fromPath("$projectDir/assets/multiqc_config_${params.assembly_type}.yml", checkIfExists: true) : channel.fromPath("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
-    ch_multiqc_custom_config              = params.multiqc_config ? channel.fromPath(params.multiqc_config, checkIfExists: true) : channel.empty()
-    ch_multiqc_logo                       = params.multiqc_logo ? channel.fromPath(params.multiqc_logo, checkIfExists: true) : channel.empty()
-    summary_params                        = paramsSummaryMap(workflow, parameters_schema: "nextflow_schema.json")
-    ch_workflow_summary                   = channel.value(paramsSummaryMultiqc(summary_params))
-    ch_multiqc_custom_methods_description = params.multiqc_methods_description ? channel.fromPath(params.multiqc_methods_description, checkIfExists: true) : channel.fromPath("$projectDir/assets/methods_description_template.yml", checkIfExists: true)
+    multiqc_report = channel.empty()
+    if ( !params.skip_multiqc ) {
+        ch_multiqc_config                     = !params.skip_kmerfinder && params.assembly_type && params.assembly_type != 'auto' ? channel.fromPath("$projectDir/assets/multiqc_config_${params.assembly_type}.yml", checkIfExists: true) : channel.fromPath("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
+        ch_multiqc_custom_config              = params.multiqc_config ? channel.fromPath(params.multiqc_config, checkIfExists: true) : channel.empty()
+        ch_multiqc_logo                       = params.multiqc_logo ? channel.fromPath(params.multiqc_logo, checkIfExists: true) : channel.empty()
+        summary_params                        = paramsSummaryMap(workflow, parameters_schema: "nextflow_schema.json")
+        ch_workflow_summary                   = channel.value(paramsSummaryMultiqc(summary_params))
+        ch_multiqc_custom_methods_description = params.multiqc_methods_description ? channel.fromPath(params.multiqc_methods_description, checkIfExists: true) : channel.fromPath("$projectDir/assets/methods_description_template.yml", checkIfExists: true)
 
-    CUSTOM_MULTIQC (
-        ch_multiqc_config.ifEmpty([]),
-        ch_multiqc_custom_config.ifEmpty([]),
-        ch_multiqc_logo.ifEmpty([]),
-        ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'),
-        ch_multiqc_custom_methods_description.ifEmpty([]),
-        ch_collated_versions.ifEmpty([]),
-        ch_fastqc_raw_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_fastqc_trim_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_fastp_json_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_nanoplot_txt_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_porechop_log_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_filtlong_log_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_pycoqc_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_kraken_short_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_kraken_long_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_quast_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_busco_multiqc.collect{it -> it[1]}.ifEmpty([]),
-        ch_prokka_txt_multiqc.collect().ifEmpty([]),
-        ch_bakta_txt_multiqc.collect().ifEmpty([]),
-        ch_kmerfinder_multiqc.collectFile(name: 'multiqc_kmerfinder.yaml').ifEmpty([]),
-    )
+        CUSTOM_MULTIQC (
+            ch_multiqc_config.ifEmpty([]),
+            ch_multiqc_custom_config.ifEmpty([]),
+            ch_multiqc_logo.ifEmpty([]),
+            ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'),
+            ch_multiqc_custom_methods_description.ifEmpty([]),
+            ch_collated_versions.ifEmpty([]),
+            ch_fastqc_raw_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_fastqc_trim_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_fastp_json_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_nanoplot_txt_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_porechop_log_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_filtlong_log_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_pycoqc_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_kraken_short_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_kraken_long_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_quast_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_busco_multiqc.collect{it -> it[1]}.ifEmpty([]),
+            ch_prokka_txt_multiqc.collect().ifEmpty([]),
+            ch_bakta_txt_multiqc.collect().ifEmpty([]),
+            ch_kmerfinder_multiqc.collectFile(name: 'multiqc_kmerfinder.yaml').ifEmpty([]),
+        )
+        multiqc_report = CUSTOM_MULTIQC.out.report.toList()
+    }
 
     emit:
-    multiqc_report = CUSTOM_MULTIQC.out.report.toList() // channel: /path/to/multiqc_report.html
+    multiqc_report = multiqc_report // channel: /path/to/multiqc_report.html
     versions       = ch_versions                        // channel: [ path(versions.yml) ]
 
 }

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -359,6 +359,20 @@ workflow BACASS {
             error(error_string) }
     }
 
+    def assembler_sample_type_compatibility = [
+        unicycler : ['short', 'long', 'hybrid'] as Set,
+        megahit   : ['short'] as Set,
+        canu      : ['long'] as Set,
+        miniasm   : ['long'] as Set,
+        dragonflye: ['long', 'hybrid'] as Set,
+        raven     : ['long'] as Set,
+        flye      : ['long'] as Set,
+        autocycler: ['long'] as Set
+    ]
+    def filterByCompatibleAssemblyTypes = { channel_input, assembler_name ->
+        channel_input.filter { meta, _sr, _lr -> assembler_sample_type_compatibility[assembler_name].contains(meta.assembly_type) }
+    }
+
     //
     // MODULE: Autocycler, subset long reads for multiple assemblies per sample.
     //
@@ -386,18 +400,6 @@ workflow BACASS {
     // ASSEMBLY: Unicycler, Megahit, Canu, Miniasm, Dragonflye, Raven, Flye, Autocycler
     //
     ch_assembly = channel.empty()
-    def assembler_sample_type_compatibility = [
-        unicycler : ['short', 'long', 'hybrid'] as Set,
-        canu      : ['long'] as Set,
-        miniasm   : ['long'] as Set,
-        dragonflye: ['long', 'hybrid'] as Set,
-        raven     : ['long'] as Set,
-        flye      : ['long'] as Set,
-        autocycler: ['long'] as Set
-    ]
-    def filterByCompatibleAssemblyTypes = { channel_input, assembler_name ->
-        channel_input.filter { meta, _sr, _lr -> assembler_sample_type_compatibility[assembler_name].contains(meta.assembly_type) }
-    }
 
     //
     // MODULE: Unicycler, genome assembly, nf-core module allows only short, long and hybrid assembly


### PR DESCRIPTION
<!--
# nf-core/bacass pull request

Many thanks for contributing to nf-core/bacass!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
-->
## PR Description
This PR adds support for `--assembly_type auto` by inferring the effective assembly type from the input samplesheet and validating assembler compatibility accordingly.

It also adds coverage for heterogeneous samplesheets, where different samples in the same run may require different assembly strategies.

### What changed

- Added `auto` support for `--assembly_type`
- Infer per-sample assembly type from the samplesheet:
  - `short`
  - `long`
  - `hybrid`
- Support heterogeneous samplesheets by validating the selected assembler set against all detected sample types
- Update workflow routing so assemblers only receive compatible sample types
- Add/adjust nf-tests for:
  - invalid `short + canu`
  - invalid `hybrid + flye`
  - invalid `auto + heterogeneous + flye`
  - valid stubbed `auto + long-only`

### Additional fixes

- Ensure `skip_multiqc` is respected in the workflow
- Make the custom MultiQC cleanup more robust by using `rm -f`


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
