### PR TITLE
Fix conda env issues in Porechop and MultiQC_custom before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.6.0 nf-core/bacass - "Crimson Titanium Seahorse" 2026/04/16
+## v2.6.0 nf-core/bacass - "Crimson Titanium Seahorse" 2026/04/22
 
 ### `Changed`
 
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#298](https://github.com/nf-core/bacass/pull/298) Fix conda env issues in Porechop and MultiQC_custom before release
 - [#294](https://github.com/nf-core/bacass/pull/294) Update toulligqc version prior release
 - [#268](https://github.com/nf-core/bacass/pull/268) Fix test_full profile and refactor kmerfinder subworkflow (NCBI datasets migration)
 

--- a/modules.json
+++ b/modules.json
@@ -128,7 +128,7 @@
                     },
                     "porechop/porechop": {
                         "branch": "master",
-                        "git_sha": "1d68c7f248d1a480c5959548a9234602b771199e",
+                        "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
                         "installed_by": ["modules"]
                     },
                     "prokka": {

--- a/modules/local/custom/multiqc/environment.yml
+++ b/modules/local/custom/multiqc/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::multiqc=1.32
+  - bioconda::multiqc=1.19

--- a/modules/nf-core/porechop/porechop/environment.yml
+++ b/modules/nf-core/porechop/porechop/environment.yml
@@ -1,7 +1,8 @@
-name: porechop_porechop
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::porechop=0.2.4
+  - conda-forge::pigz=2.8

--- a/modules/nf-core/porechop/porechop/main.nf
+++ b/modules/nf-core/porechop/porechop/main.nf
@@ -4,8 +4,9 @@ process PORECHOP_PORECHOP {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/porechop:0.2.4--py39h7cff6ad_2' :
-        'biocontainers/porechop:0.2.4--py39h7cff6ad_2' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/2b/2bce1f10c51906a66c4c4d3a7485394f67e304177192ad1cce6cf586a3a18bae/data' :
+        'community.wave.seqera.io/library/porechop_pigz:d1655e5b5bad786c' }"
+
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/porechop/porechop/meta.yml
+++ b/modules/nf-core/porechop/porechop/meta.yml
@@ -12,34 +12,49 @@ tools:
       tool_dev_url: "https://github.com/rrwick/Porechop"
       doi: "10.1099/mgen.0.000132"
       licence: ["GPL v3"]
+      identifier: ""
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - reads:
-      type: file
-      description: fastq/fastq.gz file
-      pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: fastq/fastq.gz file
+        pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
-  - reads:
-      type: file
-      description: Demultiplexed and/or adapter-trimmed fastq.gz file
-      pattern: "*.{fastq.gz}"
-  - log:
-      type: file
-      description: Log file containing stdout information
-      pattern: "*.log"
+  reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fastq.gz":
+          type: file
+          description: Demultiplexed and/or adapter-trimmed fastq.gz file
+          pattern: "*.{fastq.gz}"
+          ontologies: []
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          type: file
+          description: Log file containing stdout information
+          pattern: "*.log"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@ggabernet"
   - "@jasmezz"

--- a/modules/nf-core/porechop/porechop/tests/main.nf.test
+++ b/modules/nf-core/porechop/porechop/tests/main.nf.test
@@ -15,9 +15,10 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [    [ id:'test', single_end:true ],
-                                file(params.test_data['sarscov2']['nanopore']['test_fastq_gz'], checkIfExists: true)
-                            ]
+                input[0] = [
+                    [ id:'test', single_end:true ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true)
+                ]
                 """
             }
         }
@@ -41,9 +42,9 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [    [ id:'test', single_end:true ],
-                                []
-                            ]
+                input[0] = [ [ id:'test', single_end:true ],
+                    []
+                ]
                 """
             }
         }

--- a/modules/nf-core/porechop/porechop/tests/tags.yml
+++ b/modules/nf-core/porechop/porechop/tests/tags.yml
@@ -1,2 +1,0 @@
-porechop/porechop:
-  - "modules/nf-core/porechop/porechop/**"


### PR DESCRIPTION
<!--
# nf-core/bacass pull request

Many thanks for contributing to nf-core/bacass!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).


## Description

This PR resolves nf-test snapshot failures caused by version inconsistencies between Docker and Conda environments for two modules.

## Changes

### 1. Porechop module
- **Issue**: Docker and Conda were using different versions of Porechop, causing test failures
- **Fix**: Updated to latest nf-core/modules version for `porechop/porechop`

### 2. Custom MultiQC module
- **Issue**: Docker used MultiQC v1.19 while Conda used v1.32, resulting in different output file naming schemes (e.g., `mqc_busco_plot_*.png` vs `busco_plot_*-cnt.png`)
- **Fix**: Match versions between docker and conda.
