### PR TITLE
Add stub support  for modules used in stub-run testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 work/
 data/
 results/
-results*
 .DS_Store
 testing/
 testing*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 work/
 data/
 results/
+results*
 .DS_Store
 testing/
 testing*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - [#310](https://github.com/nf-core/bacass/pull/310) Add BUSCO output to MultiQC
+- [#314](https://github.com/nf-core/bacass/pull/314) Add stub support for modules used in stub-run testing
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
+
+| Tool      | Previous version | New version |
+| --------- | ---------------- | ----------- |
+| Canu      | 2.2              | 2.3         |
+| Medaka    | 2.2.1            | 2.2.2       |
+
 ### `Deprecated`
 
 ## v2.6.1 nf-core/bacass - "Crimson Titanium Seahorse" 2026/06/10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
-
-| Tool      | Previous version | New version |
-| --------- | ---------------- | ----------- |
-| Canu      | 2.2              | 2.3         |
-| Medaka    | 2.2.1            | 2.2.2       |
+| Tool   | Previous version | New version |
+| ------ | ---------------- | ----------- |
+| Canu   | 2.2              | 2.3         |
+| Medaka | 2.2.1            | 2.2.2       |
 
 ### `Deprecated`
 

--- a/modules.json
+++ b/modules.json
@@ -153,7 +153,7 @@
                     },
                     "rasusa": {
                         "branch": "master",
-                        "git_sha": "35b7d3eeaccbc0c82fae2ef675b00c028b9282ca",
+                        "git_sha": "157ed9432d12a18a40e308dcd0a7a0b2a0245d2e",
                         "installed_by": ["modules"]
                     },
                     "raven": {

--- a/modules.json
+++ b/modules.json
@@ -52,7 +52,7 @@
                     },
                     "canu": {
                         "branch": "master",
-                        "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "cat/fastq": {

--- a/modules.json
+++ b/modules.json
@@ -8,183 +8,257 @@
                     "autocycler/cluster": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": ["fasta_consensus_autocycler"]
+                        "installed_by": [
+                            "fasta_consensus_autocycler"
+                        ]
                     },
                     "autocycler/combine": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": ["fasta_consensus_autocycler"]
+                        "installed_by": [
+                            "fasta_consensus_autocycler"
+                        ]
                     },
                     "autocycler/compress": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": ["fasta_consensus_autocycler"]
+                        "installed_by": [
+                            "fasta_consensus_autocycler"
+                        ]
                     },
                     "autocycler/resolve": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": ["fasta_consensus_autocycler"]
+                        "installed_by": [
+                            "fasta_consensus_autocycler"
+                        ]
                     },
                     "autocycler/subsample": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "autocycler/trim": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": ["fasta_consensus_autocycler"]
+                        "installed_by": [
+                            "fasta_consensus_autocycler"
+                        ]
                     },
                     "bakta/bakta": {
                         "branch": "master",
                         "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bakta/baktadbdownload": {
                         "branch": "master",
                         "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "busco/busco": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "canu": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "cf735af4433f2dc8e410f67012dff824ef9990eb",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "dragonflye": {
                         "branch": "master",
                         "git_sha": "ccfd6f5c2e6a24f50c7713e9a5ab887056ec9416",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "b8f1de0ac853ae5b56c63450d47438f899c553d0",
-                        "installed_by": ["fastq_trim_fastp_fastqc", "modules"]
+                        "installed_by": [
+                            "fastq_trim_fastp_fastqc",
+                            "modules"
+                        ]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "5bdb098216aaf5df9c3b6343e6204cd932503c16",
-                        "installed_by": ["fastq_trim_fastp_fastqc"]
+                        "installed_by": [
+                            "fastq_trim_fastp_fastqc"
+                        ]
                     },
                     "filtlong": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "flye": {
                         "branch": "master",
                         "git_sha": "1ab453187e9eada07bdd98609ce770971bfe86e4",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "96c57dfd98a0641886a67bd449fe33ee2ec0e374",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kraken2/kraken2": {
                         "branch": "master",
                         "git_sha": "71a39f3598935d64ffd65f0960e4d2d4a42ab778",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "liftoff": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "medaka": {
                         "branch": "master",
                         "git_sha": "13c499c244bf0e46ec222ae4fcb4074cf5eef1fe",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "megahit": {
                         "branch": "master",
                         "git_sha": "e4f18d1cecc86b39daafe8bf22343b868e696c15",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "miniasm": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "2c2d1cf80866dbd6dd0ea5d61ddd59533a72d41e",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "af27af1be706e6a2bb8fe454175b0cdf77f47b49",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "nanoplot": {
                         "branch": "master",
                         "git_sha": "9322f997f94451510f974e417ec5277869030b44",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/nanoplot/nanoplot.diff"
                     },
                     "porechop/porechop": {
                         "branch": "master",
                         "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "prokka": {
                         "branch": "master",
                         "git_sha": "2dc23692bd1c3a23a12cfd959808a8fe7e3c6557",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "quast": {
                         "branch": "master",
                         "git_sha": "55cca688337cfaec60e8cd32021bb4cd19f3a501",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "racon": {
                         "branch": "master",
-                        "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "git_sha": "6f5e41545241b6c85909febd385dad1664cd5dec",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "rasusa": {
                         "branch": "master",
                         "git_sha": "35b7d3eeaccbc0c82fae2ef675b00c028b9282ca",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "raven": {
                         "branch": "master",
-                        "git_sha": "6479ace28248469b1231819b66e0572a0af51379",
-                        "installed_by": ["modules"]
+                        "git_sha": "7f2af264386af99e70dc68ced1a46ee759f5756b",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "4352dbdb09ec40db71e9b172b97a01dcf5622c26",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "toulligqc": {
                         "branch": "master",
                         "git_sha": "d9137377f4dd6246242829772eb1949b96de1ef0",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "unicycler": {
                         "branch": "master",
-                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": ["modules"]
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/unicycler/unicycler.diff"
                     },
                     "untar": {
                         "branch": "master",
                         "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             },
@@ -193,27 +267,37 @@
                     "fasta_consensus_autocycler": {
                         "branch": "master",
                         "git_sha": "08cd59454a0718a98b68ea0e6c4e5927a07003d1",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_trim_fastp_fastqc": {
                         "branch": "master",
                         "git_sha": "b8f1de0ac853ae5b56c63450d47438f899c553d0",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "271e7fc14eb1320364416d996fb077421f3faed2",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "fdc08b8b1ae74f56686ce21f7ea11ad11990ce57",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules.json
+++ b/modules.json
@@ -112,7 +112,7 @@
                     },
                     "miniasm": {
                         "branch": "master",
-                        "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "minimap2/align": {

--- a/modules.json
+++ b/modules.json
@@ -77,7 +77,7 @@
                     },
                     "filtlong": {
                         "branch": "master",
-                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "git_sha": "83819fff250f4fe6747fd8855fb3039eea22e5b7",
                         "installed_by": ["modules"]
                     },
                     "flye": {

--- a/modules.json
+++ b/modules.json
@@ -8,257 +8,184 @@
                     "autocycler/cluster": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": [
-                            "fasta_consensus_autocycler"
-                        ]
+                        "installed_by": ["fasta_consensus_autocycler"]
                     },
                     "autocycler/combine": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": [
-                            "fasta_consensus_autocycler"
-                        ]
+                        "installed_by": ["fasta_consensus_autocycler"]
                     },
                     "autocycler/compress": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": [
-                            "fasta_consensus_autocycler"
-                        ]
+                        "installed_by": ["fasta_consensus_autocycler"]
                     },
                     "autocycler/resolve": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": [
-                            "fasta_consensus_autocycler"
-                        ]
+                        "installed_by": ["fasta_consensus_autocycler"]
                     },
                     "autocycler/subsample": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "autocycler/trim": {
                         "branch": "master",
                         "git_sha": "55492bb796dc15d32db2673fc3f269b8cb24dcb2",
-                        "installed_by": [
-                            "fasta_consensus_autocycler"
-                        ]
+                        "installed_by": ["fasta_consensus_autocycler"]
                     },
                     "bakta/bakta": {
                         "branch": "master",
                         "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bakta/baktadbdownload": {
                         "branch": "master",
                         "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "busco/busco": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "canu": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "cf735af4433f2dc8e410f67012dff824ef9990eb",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "dragonflye": {
                         "branch": "master",
                         "git_sha": "ccfd6f5c2e6a24f50c7713e9a5ab887056ec9416",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "b8f1de0ac853ae5b56c63450d47438f899c553d0",
-                        "installed_by": [
-                            "fastq_trim_fastp_fastqc",
-                            "modules"
-                        ]
+                        "installed_by": ["fastq_trim_fastp_fastqc", "modules"]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "5bdb098216aaf5df9c3b6343e6204cd932503c16",
-                        "installed_by": [
-                            "fastq_trim_fastp_fastqc"
-                        ]
+                        "installed_by": ["fastq_trim_fastp_fastqc"]
                     },
                     "filtlong": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "flye": {
                         "branch": "master",
                         "git_sha": "1ab453187e9eada07bdd98609ce770971bfe86e4",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "96c57dfd98a0641886a67bd449fe33ee2ec0e374",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "kraken2/kraken2": {
                         "branch": "master",
                         "git_sha": "71a39f3598935d64ffd65f0960e4d2d4a42ab778",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "liftoff": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "medaka": {
                         "branch": "master",
                         "git_sha": "13c499c244bf0e46ec222ae4fcb4074cf5eef1fe",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "megahit": {
                         "branch": "master",
                         "git_sha": "e4f18d1cecc86b39daafe8bf22343b868e696c15",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "miniasm": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "2c2d1cf80866dbd6dd0ea5d61ddd59533a72d41e",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "af27af1be706e6a2bb8fe454175b0cdf77f47b49",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "nanoplot": {
                         "branch": "master",
                         "git_sha": "9322f997f94451510f974e417ec5277869030b44",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/nanoplot/nanoplot.diff"
                     },
                     "porechop/porechop": {
                         "branch": "master",
                         "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "prokka": {
                         "branch": "master",
                         "git_sha": "2dc23692bd1c3a23a12cfd959808a8fe7e3c6557",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "quast": {
                         "branch": "master",
                         "git_sha": "55cca688337cfaec60e8cd32021bb4cd19f3a501",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "racon": {
                         "branch": "master",
                         "git_sha": "6f5e41545241b6c85909febd385dad1664cd5dec",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "rasusa": {
                         "branch": "master",
                         "git_sha": "35b7d3eeaccbc0c82fae2ef675b00c028b9282ca",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "raven": {
                         "branch": "master",
                         "git_sha": "7f2af264386af99e70dc68ced1a46ee759f5756b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "4352dbdb09ec40db71e9b172b97a01dcf5622c26",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "toulligqc": {
                         "branch": "master",
                         "git_sha": "d9137377f4dd6246242829772eb1949b96de1ef0",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "unicycler": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/unicycler/unicycler.diff"
                     },
                     "untar": {
                         "branch": "master",
                         "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     }
                 }
             },
@@ -267,37 +194,27 @@
                     "fasta_consensus_autocycler": {
                         "branch": "master",
                         "git_sha": "08cd59454a0718a98b68ea0e6c4e5927a07003d1",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "fastq_trim_fastp_fastqc": {
                         "branch": "master",
                         "git_sha": "b8f1de0ac853ae5b56c63450d47438f899c553d0",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "271e7fc14eb1320364416d996fb077421f3faed2",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "fdc08b8b1ae74f56686ce21f7ea11ad11990ce57",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     }
                 }
             }

--- a/modules/local/custom/multiqc/main.nf
+++ b/modules/local/custom/multiqc/main.nf
@@ -16,7 +16,7 @@ process CUSTOM_MULTIQC {
     path ('fastqc/*')
     path ('fastqc_trim/*')
     path ('fastp/*')
-    path ('nanoplot/*')
+    path ('nanoplot??/*')
     path ('porechop/*')
     path ('filtlong/*')
     path ('pycoqc/*')
@@ -57,6 +57,20 @@ process CUSTOM_MULTIQC {
 
     ## Run multiqc a second time
     multiqc -f $args $custom_config .
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch multiqc_report.html
+
+    mkdir -p multiqc_data
+    touch multiqc_data/multiqc_data.json
+    touch multiqc_data/multiqc_sources.yaml
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/dfast/main.nf
+++ b/modules/local/dfast/main.nf
@@ -40,4 +40,18 @@ process DFAST {
         dfast: \$( dfast --version | sed -e "s/DFAST ver. //g" )
     END_VERSIONS
     """
+
+    stub:
+    def prefix  = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p ${prefix}_results
+    touch ${prefix}_results/${prefix}.gff
+    touch ${prefix}_results/${prefix}.faa
+    touch ${prefix}_results/${prefix}.ffn
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        dfast: 1.3.9
+    END_VERSIONS
+    """
 }

--- a/modules/local/kmerfinder/kmerfinder/main.nf
+++ b/modules/local/kmerfinder/kmerfinder/main.nf
@@ -44,4 +44,34 @@ process KMERFINDER_KMERFINDER {
         kmerfinder: \$(echo "${kmerfinder_version}")
     END_VERSIONS
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def kmerfinder_version = "3.0.2"
+    """
+    cat <<-END_REPORT > ${prefix}_results.txt
+    GCF_000000000.1_ASM000000v1\t1\t100.00\t100.00\tStub species
+    END_REPORT
+
+    cat <<-END_JSON > ${prefix}_data.json
+    {
+      "kmerfinder": {
+        "results": {
+          "species_hits": [
+            {
+              "value": {
+                "Species": "Stub species"
+              }
+            }
+          ]
+        }
+      }
+    }
+    END_JSON
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kmerfinder: \$(echo "${kmerfinder_version}")
+    END_VERSIONS
+    """
 }

--- a/modules/local/kmerfinder/summary/main.nf
+++ b/modules/local/kmerfinder/summary/main.nf
@@ -27,4 +27,23 @@ process KMERFINDER_SUMMARY {
         python: \$(python --version | awk '{print \$2}')
     END_VERSIONS
     """
+
+    stub:
+    """
+    cat <<-END_CSV > kmerfinder_summary.csv
+    sample_name,species,accession
+    stub,Stub species,GCF_000000000.1_ASM000000v1
+    END_CSV
+
+    cat <<-END_YAML > kmerfinder_summary.yaml
+    stub:
+      species: Stub species
+      accession: GCF_000000000.1_ASM000000v1
+    END_YAML
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | awk '{print \$2}')
+    END_VERSIONS
+    """
 }

--- a/modules/local/kraken2/db_preparation/main.nf
+++ b/modules/local/kraken2/db_preparation/main.nf
@@ -29,4 +29,15 @@ process KRAKEN2_DB_PREPARATION {
         tar: \$(tar --version | sed -n 's/^tar (GNU tar) \$([0-9.]*\$).*/\$1/p')
     END_VERSIONS
     """
+
+    stub:
+    """
+    mkdir database
+    touch database/hash.k2d
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        tar: \$(tar --version | sed -n 's/^tar (GNU tar) \$([0-9.]*\$).*/\$1/p')
+    END_VERSIONS
+    """
 }

--- a/modules/local/nanopolish/main.nf
+++ b/modules/local/nanopolish/main.nf
@@ -39,4 +39,14 @@ process NANOPOLISH {
         nanopolish: \$( nanopolish --version | sed -e "s/nanopolish version //g" | head -n 1 )
     END_VERSIONS
     """
+
+    stub:
+    """
+    touch polished_genome.fa
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        nanopolish: 0.14.0
+    END_VERSIONS
+    """
 }

--- a/modules/local/pycoqc/main.nf
+++ b/modules/local/pycoqc/main.nf
@@ -38,4 +38,16 @@ process PYCOQC {
         pycoqc: \$(pycoQC --version 2>&1 | sed 's/^.*pycoQC v//; s/ .*\$//')
     END_VERSIONS
     """
+
+    stub:
+    def prefix      = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.html
+    echo '{}' > ${prefix}.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pycoqc: 2.5.2
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/canu/environment.yml
+++ b/modules/nf-core/canu/environment.yml
@@ -1,7 +1,9 @@
-name: canu
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - bioconda::canu=2.2
+  - bioconda::canu=2.3=h3fb4750_1
+  - bioconda::minimap2=2.28
+  - bioconda::samtools=1.21

--- a/modules/nf-core/canu/main.nf
+++ b/modules/nf-core/canu/main.nf
@@ -2,10 +2,11 @@ process CANU {
     tag "$meta.id"
     label 'process_high'
 
+    // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/canu:2.2--ha47f30e_0':
-        'biocontainers/canu:2.2--ha47f30e_0' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/canu:2.3--h3fb4750_1':
+        'quay.io/biocontainers/canu:2.3--h3fb4750_1' }"
 
     input:
     tuple val(meta), path(reads)
@@ -21,7 +22,10 @@ process CANU {
     tuple val(meta), path("*.contigs.layout")           , emit: metadata                , optional: true
     tuple val(meta), path("*.contigs.layout.readToTig") , emit: contig_position         , optional: true
     tuple val(meta), path("*.contigs.layout.tigInfo")   , emit: contig_info             , optional: true
-    path "versions.yml"                                 , emit: versions
+    // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    tuple val("${task.process}"), val('canu'), val("2.3"), emit: versions_canu, topic: versions
+    tuple val("${task.process}"), val("minimap2"), eval("minimap2 --version"), emit: versions_minimap2, topic: versions
+    tuple val("${task.process}"), val('samtools'), eval("samtools version | sed '1!d;s/.* //'"), emit: versions_samtools, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -34,17 +38,32 @@ process CANU {
     """
     canu \\
         -p ${prefix} \\
-        $mode \\
         genomeSize=${genomesize} \\
         $args \\
         maxThreads=$task.cpus \\
-        $reads
+        $mode $reads
 
     gzip *.fasta
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        canu: \$(echo \$(canu --version 2>&1) | sed 's/^.*canu //; s/Using.*\$//' )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args = task.ext.args ?: ''
+    def trimmed_cmd = args.contains("-trimmed") ? "-trimmed" : ""
+    def corrected_cmd = args.contains("-corrected") ? "-corrected" : ""
+    """
+    echo "" | gzip > ${prefix}.contigs.fasta.gz
+    echo "" | gzip > ${prefix}.unassembled.fasta.gz
+    if [ "${corrected_cmd}" != "" ]; then
+        echo "" | gzip > ${prefix}.correctedReads.fasta.gz
+    fi
+
+    if [ "${trimmed_cmd}" != "" ]; then
+        echo "" | gzip > ${prefix}.trimmedReads.fasta.gz
+    fi
+    touch ${prefix}.contigs.layout
+    touch ${prefix}.contigs.layout.readToTig
+    touch ${prefix}.contigs.layout.tigInfo
+    touch ${prefix}.report
     """
 }

--- a/modules/nf-core/canu/meta.yml
+++ b/modules/nf-core/canu/meta.yml
@@ -1,5 +1,6 @@
 name: "canu"
-description: Accurate assembly of segmental duplications, satellites, and allelic variants from high-fidelity long reads.
+description: Accurate assembly of segmental duplications, satellites, and
+  allelic variants from high-fidelity long reads.
 keywords:
   - Assembly
   - pacbio
@@ -7,72 +8,190 @@ keywords:
   - nanopore
 tools:
   - "canu":
-      description: "Canu is a fork of the Celera Assembler designed for high-noise single-molecule sequencing."
+      description: "Canu is a fork of the Celera Assembler designed for high-noise single-molecule
+        sequencing."
       homepage: "https://canu.readthedocs.io/en/latest/index.html#"
       documentation: "https://canu.readthedocs.io/en/latest/tutorial.html"
       tool_dev_url: "https://github.com/marbl/canu"
       doi: "10.1101/gr.215087.116"
-      licence: "['GPL v2 and others']"
+      licence:
+        - "GPL v2 and others"
+      identifier: biotools:canu
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:true ]
-  - reads:
-      type: file
-      description: fasta/fastq file
-      pattern: "*.{fasta,fastq}"
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:true ]
+    - reads:
+        type: file
+        description: fasta/fastq file
+        pattern: "*.{fasta,fastq}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
   - mode:
-      type: value
+      type: string
       description: Canu mode depending on the input data (source and error rate)
       pattern: "-pacbio|-nanopore|-pacbio-hifi"
   - genomesize:
-      type: value
-      description: An estimate of the size of the genome. Common suffices are allowed, for example, 3.7m or 2.8g
+      type: string
+      description: An estimate of the size of the genome. Common suffices are
+        allowed, for example, 3.7m or 2.8g
       pattern: "<number>[g|m|k]"
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
-  - report:
-      type: file
-      description: Most of the analysis reported during assembly
-      pattern: "*.report"
-  - assembly:
-      type: file
-      description: Everything which could be assembled and is the full assembly, including both unique, repetitive, and bubble elements.
-      pattern: "*.contigs.fasta"
-  - contigs:
-      type: file
-      description: Reads and low-coverage contigs which could not be incorporated into the primary assembly.
-      pattern: "*.unassembled.fasta"
-  - corrected_reads:
-      type: file
-      description: The reads after correction.
-      pattern: "*.correctedReads.fasta.gz"
-  - corrected_trimmed_reads:
-      type: file
-      description: The corrected reads after overlap based trimming
-      pattern: "*.trimmedReads.fasta.gz"
-  - metadata:
-      type: file
-      description: (undocumented)
-      pattern: "*.contigs.layout"
-  - contig_position:
-      type: file
-      description: The position of each read in a contig
-      pattern: "*.contigs.layout.readToTig"
-  - contig_info:
-      type: file
-      description: A list of the contigs, lengths, coverage, number of reads and other metadata. Essentially the same information provided in the FASTA header line.
-      pattern: "*.contigs.layout.tigInfo"
+  report:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.report":
+          type: file
+          description: Most of the analysis reported during assembly
+          pattern: "*.report"
+          ontologies: []
+  assembly:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.contigs.fasta.gz":
+          type: file
+          description: Everything which could be assembled and is the full
+            assembly, including both unique, repetitive, and bubble elements.
+          pattern: "*.contigs.fasta"
+          ontologies: []
+  contigs:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.unassembled.fasta.gz":
+          type: file
+          description: Reads and low-coverage contigs which could not be
+            incorporated into the primary assembly.
+          pattern: "*.unassembled.fasta"
+          ontologies: []
+  corrected_reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.correctedReads.fasta.gz":
+          type: file
+          description: The reads after correction.
+          pattern: "*.correctedReads.fasta.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP
+  corrected_trimmed_reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.trimmedReads.fasta.gz":
+          type: file
+          description: The corrected reads after overlap based trimming
+          pattern: "*.trimmedReads.fasta.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP
+  metadata:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.contigs.layout":
+          type: file
+          description: (undocumented)
+          pattern: "*.contigs.layout"
+          ontologies: []
+  contig_position:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.contigs.layout.readToTig":
+          type: file
+          description: The position of each read in a contig
+          pattern: "*.contigs.layout.readToTig"
+          ontologies: []
+  contig_info:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.contigs.layout.tigInfo":
+          type: file
+          description: A list of the contigs, lengths, coverage, number of reads
+            and other metadata. Essentially the same information provided in the
+            FASTA header line.
+          pattern: "*.contigs.layout.tigInfo"
+          ontologies: []
+  versions_canu:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - canu:
+          type: string
+          description: The name of the tool
+      - "2.3":
+          type: string
+          description: The expression to obtain the version of the tool
+  versions_minimap2:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - minimap2:
+          type: string
+          description: The name of the tool
+      - minimap2 --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_samtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - canu:
+          type: string
+          description: The name of the tool
+      - "2.3":
+          type: string
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - minimap2:
+          type: string
+          description: The name of the tool
+      - minimap2 --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@scorreard"
 maintainers:

--- a/modules/nf-core/canu/tests/main.nf.test
+++ b/modules/nf-core/canu/tests/main.nf.test
@@ -1,0 +1,64 @@
+nextflow_process {
+
+    name "Test Process CANU"
+    config "./nextflow.config"
+    script "../main.nf"
+    process "CANU"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "canu"
+
+    test("test_hicanu") {
+        when {
+            params {
+                module_args = "maxInputCoverage=800 minOverlapLength=1 hapThreads=1 corThreads=1 minInputCoverage=0 stopOnLowCoverage=0 maxMemory=7" +
+                    " merylMemory=7 merylThreads=1 batMemory=7 batThreads=1 redMemory=7 redThreads=1 oeaMemory=7 oeaThreads=1" +
+                    " obtovlThreads=1 utgovlThreads=1"
+            }
+            process {
+                """
+                input[0] = [
+                    [id:'test', single_end:true],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/fastq/test_hifi.fastq.gz', checkIfExists:true)
+                    ]
+                input[1] = "-pacbio-hifi"
+                input[2] = '10k'
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("test_hicanu - stub") {
+        options "-stub"
+        when {
+            params {
+                module_args = "mmaxInputCoverage=800 inOverlapLength=1 hapThreads=1 corThreads=1 minInputCoverage=0 stopOnLowCoverage=0 maxMemory=7" +
+                    " merylMemory=7 merylThreads=1 batMemory=7 batThreads=1 redMemory=7 redThreads=1 oeaMemory=7 oeaThreads=1" +
+                    " obtovlThreads=1 utgovlThreads=1"
+            }
+            process {
+                """
+                input[0] = [
+                    [id:'test', single_end:true],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/fastq/test_hifi.fastq.gz', checkIfExists:true)
+                    ]
+                input[1] = "-pacbio-hifi"
+                input[2] = '10k'
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/canu/tests/main.nf.test.snap
+++ b/modules/nf-core/canu/tests/main.nf.test.snap
@@ -1,0 +1,180 @@
+{
+    "test_hicanu - stub": {
+        "content": [
+            {
+                "assembly": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.contigs.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "contig_info": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.contigs.layout.tigInfo:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "contig_position": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.contigs.layout.readToTig:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "contigs": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.unassembled.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "corrected_reads": [
+                    
+                ],
+                "corrected_trimmed_reads": [
+                    
+                ],
+                "metadata": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.contigs.layout:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.report:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_canu": [
+                    [
+                        "CANU",
+                        "canu",
+                        "2.3"
+                    ]
+                ],
+                "versions_minimap2": [
+                    [
+                        "CANU",
+                        "minimap2",
+                        "2.28-r1209"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "CANU",
+                        "samtools",
+                        "1.21"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-15T14:36:35.695589276",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.03.1"
+        }
+    },
+    "test_hicanu": {
+        "content": [
+            {
+                "assembly": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.contigs.fasta.gz:md5,aeb2768e013506b25b6778ddadb77466"
+                    ]
+                ],
+                "contig_info": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.contigs.layout.tigInfo:md5,092286fa522a008e628b533eb56f7ff6"
+                    ]
+                ],
+                "contig_position": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.contigs.layout.readToTig:md5,ed2086b99f8f86607d8b1c793bae5096"
+                    ]
+                ],
+                "contigs": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.unassembled.fasta.gz:md5,8e108c4bcef54fef9f1cff3c8b53182e"
+                    ]
+                ],
+                "corrected_reads": [
+                    
+                ],
+                "corrected_trimmed_reads": [
+                    
+                ],
+                "metadata": [
+                    
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.report:md5,5108f1eaf984efa72b592507d6a5b1cb"
+                    ]
+                ],
+                "versions_canu": [
+                    [
+                        "CANU",
+                        "canu",
+                        "2.3"
+                    ]
+                ],
+                "versions_minimap2": [
+                    [
+                        "CANU",
+                        "minimap2",
+                        "2.28-r1209"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "CANU",
+                        "samtools",
+                        "1.21"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-15T15:29:07.078269551",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.03.1"
+        }
+    }
+}

--- a/modules/nf-core/canu/tests/nextflow.config
+++ b/modules/nf-core/canu/tests/nextflow.config
@@ -1,0 +1,8 @@
+process {
+    resourceLimits = [
+        cpus: 1
+    ]
+    withName: "CANU" {
+        ext.args = params.module_args
+    }
+}

--- a/modules/nf-core/filtlong/main.nf
+++ b/modules/nf-core/filtlong/main.nf
@@ -3,9 +3,9 @@ process FILTLONG {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/filtlong:0.2.1--h9a82719_0' :
-        'biocontainers/filtlong:0.2.1--h9a82719_0' }"
+        'quay.io/biocontainers/filtlong:0.2.1--h9a82719_0' }"
 
     input:
     tuple val(meta), path(shortreads), path(longreads)
@@ -13,7 +13,7 @@ process FILTLONG {
     output:
     tuple val(meta), path("*.fastq.gz"), emit: reads
     tuple val(meta), path("*.log")     , emit: log
-    path "versions.yml"                 , emit: versions
+    tuple val("${task.process}"), val('filtlong'), eval('filtlong --version | sed -e "s/Filtlong v//g"'), topic: versions, emit: versions_filtlong
 
     when:
     task.ext.when == null || task.ext.when
@@ -28,12 +28,14 @@ process FILTLONG {
         $short_reads \\
         $args \\
         $longreads \\
-        2> >(tee ${prefix}.log >&2) \\
+        2>| >(tee ${prefix}.log >&2) \\
         | gzip -n > ${prefix}.fastq.gz
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        filtlong: \$( filtlong --version | sed -e "s/Filtlong v//g" )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}.fastq.gz
+    touch ${prefix}.log
     """
 }

--- a/modules/nf-core/filtlong/meta.yml
+++ b/modules/nf-core/filtlong/meta.yml
@@ -1,5 +1,6 @@
 name: filtlong
-description: Filtlong filters long reads based on quality measures or short read data.
+description: Filtlong filters long reads based on quality measures or short read
+  data.
 keywords:
   - nanopore
   - quality control
@@ -9,13 +10,14 @@ keywords:
   - short reads
 tools:
   - filtlong:
-      description: Filtlong is a tool for filtering long reads. It can take a set of
-        long reads and produce a smaller, better subset. It uses both read length (longer
-        is better) and read identity (higher is better) when choosing which reads pass
-        the filter.
+      description: Filtlong is a tool for filtering long reads. It can take a set
+        of long reads and produce a smaller, better subset. It uses both read
+        length (longer is better) and read identity (higher is better) when
+        choosing which reads pass the filter.
       homepage: https://anaconda.org/bioconda/filtlong
       tool_dev_url: https://github.com/rrwick/Filtlong
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: biotools:filtlong
 input:
   - - meta:
@@ -27,13 +29,17 @@ input:
         type: file
         description: fastq file
         pattern: "*.{fq,fastq,fq.gz,fastq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930
     - longreads:
         type: file
         description: fastq file
         pattern: "*.{fq,fastq,fq.gz,fastq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930
 output:
-  - reads:
-      - meta:
+  reads:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -42,8 +48,10 @@ output:
           type: file
           description: Filtered (compressed) fastq file
           pattern: "*.fastq.gz"
-  - log:
-      - meta:
+          ontologies:
+            - edam: http://edamontology.org/format_3989
+  log:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -52,11 +60,28 @@ output:
           type: file
           description: Standard error logging file containing summary statistics
           pattern: "*.log"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions_filtlong:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - filtlong:
+          type: string
+          description: The tool name
+      - 'filtlong --version | sed -e "s/Filtlong v//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - filtlong:
+          type: string
+          description: The tool name
+      - 'filtlong --version | sed -e "s/Filtlong v//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@d4straub"
   - "@sofstam"

--- a/modules/nf-core/filtlong/tests/main.nf.test
+++ b/modules/nf-core/filtlong/tests/main.nf.test
@@ -29,11 +29,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
-                { assert snapshot(
-                    process.out.reads,
-                    process.out.versions
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 
@@ -61,11 +57,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
-                { assert snapshot(
-                    process.out.reads,
-                    process.out.versions
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 
@@ -96,11 +88,35 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
-                { assert snapshot(
-                    process.out.reads,
-                    process.out.versions
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 nanopore [fastq] - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    [],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true) ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/filtlong/tests/main.nf.test.snap
+++ b/modules/nf-core/filtlong/tests/main.nf.test.snap
@@ -1,65 +1,146 @@
 {
     "sarscov2 nanopore [fastq]": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_lr.log:md5,99b1a8e5c6debbb0754872498f0614d7"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                    ]
+                ],
+                "versions_filtlong": [
+                    [
+                        "FILTLONG",
+                        "filtlong",
+                        "0.2.1"
+                    ]
                 ]
-            ],
-            [
-                "versions.yml:md5,af5988f30157282acdb0ac50ebb4c8cc"
-            ]
+            }
         ],
+        "timestamp": "2026-04-29T14:47:05.469854",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-08-06T10:51:29.197603"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 nanopore [fastq] - stub": {
+        "content": [
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_lr.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_lr.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_filtlong": [
+                    [
+                        "FILTLONG",
+                        "filtlong",
+                        "0.2.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T14:47:17.623243",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 nanopore [fastq] + Illumina paired-end [fastq]": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_lr.log:md5,5dc53086954a5b01c38aa7945ea4a7af"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                    ]
+                ],
+                "versions_filtlong": [
+                    [
+                        "FILTLONG",
+                        "filtlong",
+                        "0.2.1"
+                    ]
                 ]
-            ],
-            [
-                "versions.yml:md5,af5988f30157282acdb0ac50ebb4c8cc"
-            ]
+            }
         ],
+        "timestamp": "2026-04-29T14:47:14.186871",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-08-06T10:51:39.68464"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 nanopore [fastq] + Illumina single-end [fastq]": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_lr.log:md5,1540be73c90d4ca7bf23b26151cc84b7"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                    ]
+                ],
+                "versions_filtlong": [
+                    [
+                        "FILTLONG",
+                        "filtlong",
+                        "0.2.1"
+                    ]
                 ]
-            ],
-            [
-                "versions.yml:md5,af5988f30157282acdb0ac50ebb4c8cc"
-            ]
+            }
         ],
+        "timestamp": "2026-04-29T14:47:09.924687",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-08-06T10:51:34.404022"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/miniasm/environment.yml
+++ b/modules/nf-core/miniasm/environment.yml
@@ -1,7 +1,7 @@
-name: miniasm
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::miniasm=0.3_r179

--- a/modules/nf-core/miniasm/main.nf
+++ b/modules/nf-core/miniasm/main.nf
@@ -3,9 +3,9 @@ process MINIASM {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/miniasm:0.3_r179--h5bf99c6_2' :
-        'biocontainers/miniasm:0.3_r179--h5bf99c6_2' }"
+        'quay.io/biocontainers/miniasm:0.3_r179--h5bf99c6_2' }"
 
     input:
     tuple val(meta), path(reads), path(paf)
@@ -13,7 +13,7 @@ process MINIASM {
     output:
     tuple val(meta), path("*.gfa.gz")  , emit: gfa
     tuple val(meta), path("*.fasta.gz"), emit: assembly
-    path "versions.yml"                , emit: versions
+    tuple val("${task.process}"), val('miniasm'), eval('miniasm -V 2>&1'), emit: versions_miniasm, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -33,9 +33,14 @@ process MINIASM {
     gzip -n ${prefix}.gfa
     gzip -n ${prefix}.fasta
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        miniasm: \$( miniasm -V 2>&1 )
-    END_VERSIONS
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}.gfa.gz
+    echo "" | gzip > ${prefix}.fasta.gz
+
+    """
+
 }

--- a/modules/nf-core/miniasm/meta.yml
+++ b/modules/nf-core/miniasm/meta.yml
@@ -6,44 +6,77 @@ keywords:
   - nanopore
 tools:
   - miniasm:
-      description: Ultrafast de novo assembly for long noisy reads (though having no consensus step)
+      description: Ultrafast de novo assembly for long noisy reads (though having no
+        consensus step)
       homepage: https://github.com/lh3/miniasm
       documentation: https://github.com/lh3/miniasm
       tool_dev_url: https://github.com/lh3/miniasm
       doi: "10.1093/bioinformatics/btw152"
       licence: ["MIT"]
+      identifier: biotools:miniasm
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - reads:
-      type: file
-      description: List of input PacBio/ONT FastQ files.
-      pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
-  - paf:
-      type: file
-      description: Alignment in PAF format
-      pattern: "*{.paf,.paf.gz}"
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: List of input PacBio/ONT FastQ files.
+        pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+    - paf:
+        type: file
+        description: Alignment in PAF format
+        pattern: "*{.paf,.paf.gz}"
+        ontologies: []
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
-  - gfa:
-      type: file
-      description: Assembly graph
-      pattern: "*.gfa.gz"
-  - assembly:
-      type: file
-      description: Genome assembly
-      pattern: "*.fasta.gz"
+  gfa:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.gfa.gz":
+          type: file
+          description: Assembly graph
+          pattern: "*.gfa.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  assembly:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fasta.gz":
+          type: file
+          description: Genome assembly
+          pattern: "*.fasta.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  versions_miniasm:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - miniasm:
+          type: string
+          description: The tool name
+      - miniasm -V 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - miniasm:
+          type: string
+          description: The name of the tool
+      - miniasm -V 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@avantonder"
 maintainers:

--- a/modules/nf-core/miniasm/tests/main.nf.test
+++ b/modules/nf-core/miniasm/tests/main.nf.test
@@ -1,0 +1,58 @@
+// nf-core modules test miniasm
+nextflow_process {
+
+    name "Test Process MINIASM"
+    script "../main.nf"
+    process "MINIASM"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "miniasm"
+
+    test("bacteroides_fragilis - [fastq.gz, paf]- fasta") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/overlap.paf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("bacteroides_fragilis - [fastq.gz, paf]- fasta - stub") {
+        options "--stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/overlap.paf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/miniasm/tests/main.nf.test.snap
+++ b/modules/nf-core/miniasm/tests/main.nf.test.snap
@@ -1,0 +1,124 @@
+{
+    "bacteroides_fragilis - [fastq.gz, paf]- fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.gfa.gz:md5,60e8b0c635905d20bc5296710749abde"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fasta.gz:md5,3c0c2f48e6e366b43f7a12c43f7cb9e8"
+                    ]
+                ],
+                "2": [
+                    [
+                        "MINIASM",
+                        "miniasm",
+                        "0.3-r179"
+                    ]
+                ],
+                "assembly": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fasta.gz:md5,3c0c2f48e6e366b43f7a12c43f7cb9e8"
+                    ]
+                ],
+                "gfa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.gfa.gz:md5,60e8b0c635905d20bc5296710749abde"
+                    ]
+                ],
+                "versions_miniasm": [
+                    [
+                        "MINIASM",
+                        "miniasm",
+                        "0.3-r179"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T16:50:51.951168082"
+    },
+    "bacteroides_fragilis - [fastq.gz, paf]- fasta - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.gfa.gz:md5,60e8b0c635905d20bc5296710749abde"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fasta.gz:md5,3c0c2f48e6e366b43f7a12c43f7cb9e8"
+                    ]
+                ],
+                "2": [
+                    [
+                        "MINIASM",
+                        "miniasm",
+                        "0.3-r179"
+                    ]
+                ],
+                "assembly": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fasta.gz:md5,3c0c2f48e6e366b43f7a12c43f7cb9e8"
+                    ]
+                ],
+                "gfa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.gfa.gz:md5,60e8b0c635905d20bc5296710749abde"
+                    ]
+                ],
+                "versions_miniasm": [
+                    [
+                        "MINIASM",
+                        "miniasm",
+                        "0.3-r179"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-22T16:50:58.724404158"
+    }
+}

--- a/modules/nf-core/racon/environment.yml
+++ b/modules/nf-core/racon/environment.yml
@@ -4,5 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::multiqc=1.27
   - bioconda::racon=1.4.20

--- a/modules/nf-core/racon/main.nf
+++ b/modules/nf-core/racon/main.nf
@@ -3,16 +3,16 @@ process RACON {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/racon:1.4.20--h9a82719_1' :
-        'biocontainers/racon:1.4.20--h9a82719_1' }"
+        'quay.io/biocontainers/racon:1.4.20--h9a82719_1' }"
 
     input:
     tuple val(meta), path(reads), path(assembly), path(paf)
 
     output:
-    tuple val(meta), path('*.consensus.fasta.gz') , emit: improved_assembly
-    path "versions.yml"          , emit: versions
+    tuple val(meta), path('*_assembly_consensus.fasta.gz') , emit: improved_assembly
+    tuple val("${task.process}"), val('racon'), eval('racon --version 2>&1 | sed "s/^.*v//"'), emit: versions_racon, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,13 +26,14 @@ process RACON {
         "${paf}" \\
         $args \\
         "${assembly}" > \\
-        ${prefix}.consensus.fasta
+        ${prefix}_assembly_consensus.fasta
 
-    gzip -n ${prefix}.consensus.fasta
+    gzip -n ${prefix}_assembly_consensus.fasta
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        racon: \$( racon --version 2>&1 | sed 's/^.*v//' )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}_assembly_consensus.fasta.gz
     """
 }

--- a/modules/nf-core/racon/meta.yml
+++ b/modules/nf-core/racon/meta.yml
@@ -1,5 +1,6 @@
 name: racon
-description: Consensus module for raw de novo DNA assembly of long uncorrected reads
+description: Consensus module for raw de novo DNA assembly of long uncorrected
+  reads
 keywords:
   - assembly
   - pacbio
@@ -7,44 +8,71 @@ keywords:
   - polish
 tools:
   - racon:
-      description: Ultrafast consensus module for raw de novo genome assembly of long uncorrected reads.
+      description: Ultrafast consensus module for raw de novo genome assembly of
+        long uncorrected reads.
       homepage: https://github.com/lbcb-sci/racon
       documentation: https://github.com/lbcb-sci/racon
       tool_dev_url: https://github.com/lbcb-sci/racon
       doi: 10.1101/gr.214270.116
-      licence: ["MIT"]
+      licence:
+        - "MIT"
+      identifier: biotools:Racon
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - reads:
-      type: file
-      description: List of input FastQ files. Racon expects single end reads
-      pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
-  - assembly:
-      type: file
-      description: Genome assembly to be improved
-      pattern: "*.{fasta,fa}"
-  - paf:
-      type: file
-      description: Alignment in PAF format
-      pattern: "*.paf"
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: List of input FastQ files. Racon expects single end reads
+        pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930
+    - assembly:
+        type: file
+        description: Genome assembly to be improved
+        pattern: "*.{fasta,fa}"
+        ontologies: []
+    - paf:
+        type: file
+        description: Alignment in PAF format
+        pattern: "*.paf"
+        ontologies: []
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
-  - improved_assembly:
-      type: file
-      description: Improved genome assembly
-      pattern: "*_assembly_consensus.fasta.gz"
+  improved_assembly:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*_assembly_consensus.fasta.gz":
+          type: file
+          description: Improved genome assembly
+          pattern: "*_assembly_consensus.fasta.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989
+  versions_racon:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - racon:
+          type: string
+          description: The name of the tool
+      - racon --version 2>&1 | sed "s/^.*v//":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - racon:
+          type: string
+          description: The name of the tool
+      - racon --version 2>&1 | sed "s/^.*v//":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@avantonder"
 maintainers:

--- a/modules/nf-core/racon/tests/main.nf.test
+++ b/modules/nf-core/racon/tests/main.nf.test
@@ -1,0 +1,60 @@
+nextflow_process {
+
+    name "Test Process RACON"
+    script "../main.nf"
+    process "RACON"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "racon"
+
+    test("single-end - bacteroides_fragilis - [fastq_gz, fna_gz, paf]") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.paf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("single-end - bacteroides_fragilis - [fastq_gz, fna_gz, paf] - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.paf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+}

--- a/modules/nf-core/racon/tests/main.nf.test.snap
+++ b/modules/nf-core/racon/tests/main.nf.test.snap
@@ -1,0 +1,56 @@
+{
+    "single-end - bacteroides_fragilis - [fastq_gz, fna_gz, paf] - stub": {
+        "content": [
+            {
+                "improved_assembly": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_assembly_consensus.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_racon": [
+                    [
+                        "RACON",
+                        "racon",
+                        "1.4.20"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T17:03:57.718531",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "single-end - bacteroides_fragilis - [fastq_gz, fna_gz, paf]": {
+        "content": [
+            {
+                "improved_assembly": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test_assembly_consensus.fasta.gz:md5,e610bf2e1df1701b88675e36a844baf9"
+                    ]
+                ],
+                "versions_racon": [
+                    [
+                        "RACON",
+                        "racon",
+                        "1.4.20"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T17:03:47.50875",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/rasusa/main.nf
+++ b/modules/nf-core/rasusa/main.nf
@@ -3,9 +3,9 @@ process RASUSA {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/rasusa:0.3.0--h779adbc_1' :
-        'biocontainers/rasusa:0.3.0--h779adbc_1' }"
+        'quay.io/biocontainers/rasusa:0.3.0--h779adbc_1' }"
 
     input:
     tuple val(meta), path(reads), val(genome_size)
@@ -29,5 +29,14 @@ process RASUSA {
         --genome-size $genome_size \\
         --input $reads \\
         $output
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}_1.fastq.gz
+    if [ "${meta.single_end}" == "false" ]; then
+        echo "" | gzip > ${prefix}_2.fastq.gz
+    fi
     """
 }

--- a/modules/nf-core/rasusa/meta.yml
+++ b/modules/nf-core/rasusa/meta.yml
@@ -11,7 +11,8 @@ tools:
       documentation: https://github.com/mbhall88/rasusa/blob/master/README.md
       tool_dev_url: https://github.com/mbhall88/rasusa
       doi: "10.5281/zenodo.3731394"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:rasusa
 input:
   - - meta:
@@ -52,7 +53,6 @@ output:
       - 'rasusa --version 2>&1 | sed -e "s/rasusa //g"':
           type: eval
           description: The expression to obtain the version of the tool
-
 topics:
   versions:
     - - ${task.process}:

--- a/modules/nf-core/rasusa/tests/main.nf.test
+++ b/modules/nf-core/rasusa/tests/main.nf.test
@@ -29,7 +29,37 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("Should run without failures - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] =  [ [ id:'testfile', single_end:false], // meta map
+                                [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                  file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                                ],
+                                "1000000b"
+                            ]
+                input[1] = 100
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/rasusa/tests/main.nf.test.snap
+++ b/modules/nf-core/rasusa/tests/main.nf.test.snap
@@ -1,26 +1,37 @@
 {
-    "Should run without failures": {
+    "Should run without failures - stub": {
         "content": [
             {
-                "0": [
+                "reads": [
                     [
                         {
                             "id": "testfile",
                             "single_end": false
                         },
                         [
-                            "testfile_1.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec",
-                            "testfile_2.fastq.gz:md5,2ebae722295ea66d84075a3b042e2b42"
+                            "testfile_1.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "testfile_2.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
-                "1": [
+                "versions_rasusa": [
                     [
                         "RASUSA",
                         "rasusa",
                         "0.3.0"
                     ]
-                ],
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T14:51:44.171586",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Should run without failures": {
+        "content": [
+            {
                 "reads": [
                     [
                         {
@@ -42,10 +53,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-29T14:51:40.458162",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-31T14:08:55.918357445"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/raven/main.nf
+++ b/modules/nf-core/raven/main.nf
@@ -3,9 +3,9 @@ process RAVEN {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/raven-assembler:1.6.1--h2e03b76_0' :
-        'biocontainers/raven-assembler:1.6.1--h2e03b76_0' }"
+        'quay.io/biocontainers/raven-assembler:1.6.1--h2e03b76_0' }"
 
     input:
     tuple val(meta), path(reads)
@@ -32,5 +32,12 @@ process RAVEN {
 
     # compress assembly graph
     gzip -c ${prefix}.gfa > ${prefix}.gfa.gz
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}.fasta.gz
+    echo "" | gzip > ${prefix}.gfa.gz
     """
 }

--- a/modules/nf-core/raven/meta.yml
+++ b/modules/nf-core/raven/meta.yml
@@ -13,7 +13,8 @@ tools:
       documentation: https://github.com/lbcb-sci/raven#usage
       tool_dev_url: https://github.com/lbcb-sci/raven
       doi: 10.1038/s43588-021-00073-4
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:raven
 input:
   - - meta:
@@ -62,7 +63,6 @@ output:
       - raven --version:
           type: eval
           description: The expression to obtain the version of the tool
-
 topics:
   versions:
     - - ${task.process}:
@@ -74,7 +74,6 @@ topics:
       - raven --version:
           type: eval
           description: The expression to obtain the version of the tool
-
 authors:
   - "@fmalmeida"
 maintainers:

--- a/modules/nf-core/raven/tests/main.nf.test
+++ b/modules/nf-core/raven/tests/main.nf.test
@@ -26,7 +26,31 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("test-raven - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+				    [ id:'test', single_end:false ], // meta map
+				    [ file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz', checkIfExists: true) ]
+				]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/raven/tests/main.nf.test.snap
+++ b/modules/nf-core/raven/tests/main.nf.test.snap
@@ -2,31 +2,6 @@
     "test-raven": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.fasta.gz:md5,775cca993a9dbcc09f7be65d801a696b"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.gfa.gz:md5,5342a527f24e7b15c5bd38c42ffd0be6"
-                    ]
-                ],
-                "2": [
-                    [
-                        "RAVEN",
-                        "raven",
-                        "1.6.1"
-                    ]
-                ],
                 "fasta": [
                     [
                         {
@@ -54,10 +29,46 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-29T15:05:10.680726",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-22T10:14:31.120844055"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "test-raven - stub": {
+        "content": [
+            {
+                "fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "gfa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gfa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_raven": [
+                    [
+                        "RAVEN",
+                        "raven",
+                        "1.6.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T15:05:19.798581",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/unicycler/main.nf
+++ b/modules/nf-core/unicycler/main.nf
@@ -3,7 +3,7 @@ process UNICYCLER {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/2b/2b9f404e2169ea74161d63d24f55d6339dc98c3745bf2442e425d5a673617fca/data' :
         'community.wave.seqera.io/library/unicycler:0.5.1--b9d21c454db1e56b' }"
 
@@ -48,8 +48,8 @@ process UNICYCLER {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
 
-    cat "" | gzip > ${prefix}.scaffolds.fa.gz
-    cat "" | gzip >  ${prefix}.assembly.gfa.gz
+    echo "" | gzip > ${prefix}.scaffolds.fa.gz
+    echo "" | gzip > ${prefix}.assembly.gfa.gz
     touch ${prefix}.unicycler.log
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/unicycler/meta.yml
+++ b/modules/nf-core/unicycler/meta.yml
@@ -25,13 +25,15 @@ input:
         description: |
           List of input Illumina FastQ files of size 1 and 2 for single-end and paired-end data,
           respectively.
+        ontologies: []
     - longreads:
         type: file
         description: |
           List of input FastQ files of size 1, PacBio or Nanopore long reads.
+        ontologies: []
 output:
-  - scaffolds:
-      - meta:
+  scaffolds:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -40,8 +42,9 @@ output:
           type: file
           description: Fasta file containing scaffolds
           pattern: "*.{scaffolds.fa.gz}"
-  - gfa:
-      - meta:
+          ontologies: []
+  gfa:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -50,8 +53,9 @@ output:
           type: file
           description: gfa file containing assembly
           pattern: "*.{assembly.gfa.gz}"
-  - log:
-      - meta:
+          ontologies: []
+  log:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -60,11 +64,14 @@ output:
           type: file
           description: unicycler log file
           pattern: "*.{log}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@JoseEspinosa"
   - "@drpatelh"

--- a/modules/nf-core/unicycler/unicycler.diff
+++ b/modules/nf-core/unicycler/unicycler.diff
@@ -1,0 +1,21 @@
+Changes in component 'nf-core/unicycler'
+'modules/nf-core/unicycler/environment.yml' is unchanged
+'modules/nf-core/unicycler/meta.yml' is unchanged
+Changes in 'unicycler/main.nf':
+--- modules/nf-core/unicycler/main.nf
++++ modules/nf-core/unicycler/main.nf
+@@ -48,8 +48,8 @@
+     def prefix = task.ext.prefix ?: "${meta.id}"
+     """
+
+-    cat "" | gzip > ${prefix}.scaffolds.fa.gz
+-    cat "" | gzip >  ${prefix}.assembly.gfa.gz
++    echo "" | gzip > ${prefix}.scaffolds.fa.gz
++    echo "" | gzip > ${prefix}.assembly.gfa.gz
+     touch ${prefix}.unicycler.log
+
+     cat <<-END_VERSIONS > versions.yml
+
+'modules/nf-core/unicycler/tests/main.nf.test' is unchanged
+'modules/nf-core/unicycler/tests/main.nf.test.snap' is unchanged
+************************************************************

--- a/tests/long_autocycler.nf.test.snap
+++ b/tests/long_autocycler.nf.test.snap
@@ -25,7 +25,9 @@
                     "busco": "5.8.3"
                 },
                 "CANU": {
-                    "canu": 2.2
+                    "canu": 2.3,
+                    "minimap2": "2.28-r1209",
+                    "samtools": 1.21
                 },
                 "FLYE": {
                     "flye": "2.9.5-b1801"
@@ -201,10 +203,10 @@
                 "trimming/longreads/porechop/TestMe.porechop.log"
             ],
             [
-                "TestMe-sample_01-canu.contigs.fasta.gz:md5,5641902b2036ef9112717dd8bb85d03e",
-                "TestMe-sample_01-canu.report:md5,900c5d6d7b25a9964ea7185e6490aa8e",
-                "TestMe-sample_02-canu.contigs.fasta.gz:md5,03a2c41c6920c9ea32e4c78689af1e93",
-                "TestMe-sample_02-canu.report:md5,678b45447750cee97b9418e3135f7a6d",
+                "TestMe-sample_01-canu.contigs.fasta.gz:md5,360b56cc871c90d34fc9929b6bb2cb2a",
+                "TestMe-sample_01-canu.report:md5,31f81ef95c077b438191e8e130d4fdab",
+                "TestMe-sample_02-canu.contigs.fasta.gz:md5,943a9a83d17c86fc0530b4ba8a938491",
+                "TestMe-sample_02-canu.report:md5,7b6bf347ac0c4dddd4fa938f824bedbe",
                 "TestMe-sample_01-raven.fasta.gz:md5,ebc67e9f0a5e5e8b20e23f90901139e2",
                 "TestMe-sample_02-raven.fasta.gz:md5,5fdfaf522526c9142bb9f62986726ca5",
                 "mqc_porechop-endtrim-barplot_1.yaml:md5,01be4aa5df6783634f6e8bb8208f550d",
@@ -214,10 +216,10 @@
                 "multiqc_nanostat.yaml:md5,3707e05541222ccbe609d6b751f33d0d"
             ]
         ],
-        "timestamp": "2026-04-20T10:09:41.528146478",
+        "timestamp": "2026-07-21T14:40:35.472521483",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/long_miniasm.nf.test.snap
+++ b/tests/long_miniasm.nf.test.snap
@@ -57,8 +57,8 @@
                 "Medaka",
                 "Medaka/TestMe-miniasm-medaka_polished_genome.fa.gz",
                 "Miniasm",
-                "Miniasm/TestMe-miniasm.consensus.fasta.gz",
                 "Miniasm/TestMe-miniasm.fasta.gz",
+                "Miniasm/TestMe-miniasm_assembly_consensus.fasta.gz",
                 "Prokka",
                 "Prokka/TestMe-miniasm-medaka",
                 "QC_longreads",
@@ -252,8 +252,8 @@
                 "trimming/longreads/porechop/TestMe.porechop.log"
             ],
             [
-                "TestMe-miniasm.consensus.fasta.gz:md5,4899e7b112077d045ecaf13daae4ae4a",
                 "TestMe-miniasm.fasta.gz:md5,cfde74bc269a51162851d9ae7c76207b",
+                "TestMe-miniasm_assembly_consensus.fasta.gz:md5,4899e7b112077d045ecaf13daae4ae4a",
                 "TestMe_longreads.txt:md5,4c2a95acdff03caa1524a5328c6ab2f5",
                 "mqc_busco_plot_bacteria_odb10_1.yaml:md5,eb1ce276ec11dcc7661c95d9e487c4a9",
                 "mqc_kraken-top-n-plot_Class.yaml:md5,057a9ddcdb8a79e6c0fd5cfb0c0f94c9",
@@ -274,7 +274,7 @@
                 "multiqc_nanostat.yaml:md5,3707e05541222ccbe609d6b751f33d0d"
             ]
         ],
-        "timestamp": "2026-07-15T13:09:20.235676354",
+        "timestamp": "2026-07-21T15:14:25.063330142",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/long_miniasm_prokka.nf.test.snap
+++ b/tests/long_miniasm_prokka.nf.test.snap
@@ -50,8 +50,8 @@
                 "Medaka",
                 "Medaka/TestMe-miniasm-medaka_polished_genome.fa.gz",
                 "Miniasm",
-                "Miniasm/TestMe-miniasm.consensus.fasta.gz",
                 "Miniasm/TestMe-miniasm.fasta.gz",
+                "Miniasm/TestMe-miniasm_assembly_consensus.fasta.gz",
                 "Prokka",
                 "Prokka/TestMe-miniasm-medaka",
                 "QC_longreads",
@@ -179,8 +179,8 @@
                 "trimming/longreads/porechop/TestMe.porechop.log"
             ],
             [
-                "TestMe-miniasm.consensus.fasta.gz:md5,199994f97a7c7617af79e334ae388a46",
                 "TestMe-miniasm.fasta.gz:md5,11ae7a338e60155a4c132bd2165339cd",
+                "TestMe-miniasm_assembly_consensus.fasta.gz:md5,199994f97a7c7617af79e334ae388a46",
                 "mqc_busco_plot_bacteria_odb10_1.yaml:md5,f3fb3271509d9bccce4d6563ead439f0",
                 "mqc_porechop-endtrim-barplot_1.yaml:md5,711a2deae67088db22b1a2a462da4969",
                 "mqc_porechop-middlesplit-barplot_1.yaml:md5,dab7cce19986f3193484fd241075b221",
@@ -190,7 +190,7 @@
                 "multiqc_nanostat.yaml:md5,851c9a0693d1fc482d620fed8824ed9c"
             ]
         ],
-        "timestamp": "2026-07-15T13:12:09.640708675",
+        "timestamp": "2026-07-21T15:17:13.453626725",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/long_multiassembler.nf.test.snap
+++ b/tests/long_multiassembler.nf.test.snap
@@ -87,8 +87,8 @@
                 "Medaka/TestMe-miniasm-medaka_polished_genome.fa.gz",
                 "Medaka/TestMe-raven-medaka_polished_genome.fa.gz",
                 "Miniasm",
-                "Miniasm/TestMe-miniasm.consensus.fasta.gz",
                 "Miniasm/TestMe-miniasm.fasta.gz",
+                "Miniasm/TestMe-miniasm_assembly_consensus.fasta.gz",
                 "Prokka",
                 "Prokka/TestMe-autocycler-medaka",
                 "Prokka/TestMe-miniasm-medaka",
@@ -298,8 +298,8 @@
             [
                 "TestMe-sample_01-raven.fasta.gz:md5,ebc67e9f0a5e5e8b20e23f90901139e2",
                 "TestMe-sample_02-raven.fasta.gz:md5,5fdfaf522526c9142bb9f62986726ca5",
-                "TestMe-miniasm.consensus.fasta.gz:md5,4899e7b112077d045ecaf13daae4ae4a",
                 "TestMe-miniasm.fasta.gz:md5,cfde74bc269a51162851d9ae7c76207b",
+                "TestMe-miniasm_assembly_consensus.fasta.gz:md5,4899e7b112077d045ecaf13daae4ae4a",
                 "TestMe-raven.fasta.gz:md5,5236a351461c22c5c6ca1f86cbd13f10",
                 "mqc_porechop-endtrim-barplot_1.yaml:md5,01be4aa5df6783634f6e8bb8208f550d",
                 "mqc_porechop-middlesplit-barplot_1.yaml:md5,d7c6c6307fa5a50527bd1aa179c0dab5",
@@ -308,10 +308,10 @@
                 "multiqc_nanostat.yaml:md5,3707e05541222ccbe609d6b751f33d0d"
             ]
         ],
-        "timestamp": "2026-07-14T15:13:52.19386823",
+        "timestamp": "2026-07-21T15:36:09.827423332",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/workflows/bacass.nf
+++ b/workflows/bacass.nf
@@ -249,7 +249,6 @@ workflow BACASS {
 
             ch_longreads_filtered   = FILTLONG.out.reads
             ch_filtlong_log_multiqc = FILTLONG.out.log
-            ch_versions       = ch_versions.mix(FILTLONG.out.versions)
         }
     }
 
@@ -424,7 +423,6 @@ workflow BACASS {
             ch_for_assembly_canu.map { meta, _lr -> meta.gsize }
         )
         ch_assembly = ch_assembly.mix( CANU.out.assembly.dump(tag: 'canu') )
-        ch_versions = ch_versions.mix(CANU.out.versions)
     }
 
     //
@@ -461,7 +459,6 @@ workflow BACASS {
         MINIASM (
             ch_for_miniasm
         )
-        ch_versions = ch_versions.mix(MINIASM.out.versions)
 
         MINIMAP2_CONSENSUS (
             ch_for_assembly_miniasm,
@@ -481,7 +478,6 @@ workflow BACASS {
             ch_for_racon
         )
         ch_assembly = ch_assembly.mix( RACON.out.improved_assembly.dump(tag: 'miniasm') )
-        ch_versions = ch_versions.mix( RACON.out.versions )
     }
 
     //


### PR DESCRIPTION
<!--
# nf-core/bacass pull request

Many thanks for contributing to nf-core/bacass!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacass/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacass _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## PR description

Adds stub support for modules used in stub-run testing, including KmerFinder, custom MultiQC, Racon, Raven, and Unicycler.

- Add stubs for local KmerFinder modules.
- Add stub output for custom MultiQC.
- Add stubs for local DFAST, PycoQC, Nanopolish, and Kraken2 DB preparation modules.
- Update Canu, Filtlong, Miniasm, Racon, Rasusa, Raven, and Unicycler modules for stub-run compatibility.
- Update Racon, Raven, Canu, Filtlong, Miniasm, and Rasusa module tests/snapshots.
- Fix Unicycler stub output generation.
- Adapt workflow version handling for modules that now emit versions via `topic: versions`.
- Update changelog dependency table for v2.7.0dev.

